### PR TITLE
Fix course grid when courses are fewer than 3

### DIFF
--- a/frontend/src/components/course/CourseContainer.js
+++ b/frontend/src/components/course/CourseContainer.js
@@ -78,35 +78,62 @@ const CourseContainer = ({ courses, linkPrerequisite, activeConceptId, deleteLin
     setConceptEditState({ open: true, id, name, description })
   }
 
+  const makeGridCourseElements = () => {
+    return courses && courses.map(course =>
+      <Grid item>
+        <MaterialCourse
+          key={course.id}
+          course={course}
+          linkPrerequisite={linkPrerequisite}
+          deleteLink={deleteLink}
+          activeConceptId={activeConceptId}
+          openCourseDialog={handleCourseOpen}
+          openConceptDialog={handleConceptOpen}
+          openConceptEditDialog={handleConceptEditOpen}
+          activeCourseId={course_id}
+        />
+      </Grid>
+    )
+  }
 
   return (
     <React.Fragment>
       {
         courses && courses.length !== 0 ?
-          <Grid item xs={4} lg={6}>
+          <Grid container xs={4} lg={6}>
             {/* <Grid container alignContent="space-between" justify="space-between" spacing={0}> */}
-            <div style={{ overflowY: 'scroll', maxHeight: '90vh', display: 'flex', justifyContent: 'center' }}>
-              <Masonry
-                breakpointCols={breakpointColumnsObj}
-                className="my-masonry-grid"
-                columnClassName="my-masonry-grid_column"
-              >
-                {
-                  courses && courses.map(course =>
-                    <MaterialCourse
-                      key={course.id}
-                      course={course}
-                      linkPrerequisite={linkPrerequisite}
-                      deleteLink={deleteLink}
-                      activeConceptId={activeConceptId}
-                      openCourseDialog={handleCourseOpen}
-                      openConceptDialog={handleConceptOpen}
-                      openConceptEditDialog={handleConceptEditOpen}
-                      activeCourseId={course_id}
-                    />
-                  )
-                }
-              </Masonry>
+            <div style={{ overflowY: 'scroll', width: '100%', maxHeight: '90vh', display: 'flex', justifyContent: 'center' }}>
+              {
+                courses && courses.length < 3 ?
+                  <Grid container direction='rows' justify='space-evenly'>
+                    {
+                      makeGridCourseElements()
+                    }
+                  </Grid>
+                  :
+                  <Masonry
+                    breakpointCols={breakpointColumnsObj}
+                    className="my-masonry-grid"
+                    columnClassName="my-masonry-grid_column"
+                  >
+                    {
+                      courses && courses.map(course =>
+                        <MaterialCourse
+                          key={course.id}
+                          course={course}
+                          linkPrerequisite={linkPrerequisite}
+                          deleteLink={deleteLink}
+                          activeConceptId={activeConceptId}
+                          openCourseDialog={handleCourseOpen}
+                          openConceptDialog={handleConceptOpen}
+                          openConceptEditDialog={handleConceptEditOpen}
+                          activeCourseId={course_id}
+                        />
+                      )
+                    }
+                  </Masonry>
+              }
+
             </div>
 
             <CourseEditingDialog


### PR DESCRIPTION
**React-masonry-css** doesn't handle 3 column layout when there are only elements for 1 or 2. The layout breaks if there are fewer than 3 items on larger screen resolutions. 
- This PR fixes the issue by displaying default Mui grid when there are 2 or fewer items to show and switches to using **React-masonry-css** when there are enough items to fill all three columns.