### PR TITLE
Course heat map improvement

### DIFF
--- a/frontend/src/components/concept/ActiveConcept.js
+++ b/frontend/src/components/concept/ActiveConcept.js
@@ -23,7 +23,8 @@ import { createConceptLinkUpdate } from '../../apollo/update'
 const styles = theme => ({
   conceptName: {
     maxWidth: '70%',
-    overflowWrap: 'break-word'
+    overflowWrap: 'break-word',
+    hyphens: 'auto'
   },
   conceptCircle: {
     zIndex: 2

--- a/frontend/src/components/concept/Concept.js
+++ b/frontend/src/components/concept/Concept.js
@@ -29,7 +29,8 @@ import { useErrorStateValue, useLoginStateValue } from '../../store'
 const styles = theme => ({
   conceptName: {
     maxWidth: '60%',
-    overflowWrap: 'break-word'
+    overflowWrap: 'break-word',
+    hyphens: 'auto'
   },
   active: {
     backgroundColor: '#9ecae1',

--- a/frontend/src/components/course/ActiveCourse.js
+++ b/frontend/src/components/course/ActiveCourse.js
@@ -30,7 +30,8 @@ const styles = theme => ({
     height: '90vh'
   },
   title: {
-    overflowWrap: 'break-word'
+    overflowWrap: 'break-word',
+    hyphens: 'auto'
   },
   headerContent: {
     maxWidth: '100%'

--- a/frontend/src/components/course/Course.js
+++ b/frontend/src/components/course/Course.js
@@ -35,7 +35,8 @@ const styles = theme => ({
     paddingBottom: '0px'
   },
   title: {
-    wordBreak: 'break-word',
+    overflowWrap: 'break-word',
+    hyphens: 'auto',
     '&:hover': {
       textDecoration: 'underline',
       cursor: 'pointer'

--- a/frontend/src/components/course/CourseHeatmap.js
+++ b/frontend/src/components/course/CourseHeatmap.js
@@ -93,8 +93,8 @@ const BlankHeaderCell = (props) => {
       }}>Prerequisite</div>
       <div style={{
         position: 'absolute',
-        bottom: '2px',
-        right: '65%'
+        bottom: '4px',
+        left: '4px'
       }}>Target</div>
     </th>
   )

--- a/frontend/src/components/course/CourseHeatmap.js
+++ b/frontend/src/components/course/CourseHeatmap.js
@@ -42,7 +42,8 @@ const useStyles = makeStyles(theme => ({
   },
   sideHeaderCell: {
     boxShadow: '1px 1px 0 0 black',
-    padding: '0 10px 0 0'
+    padding: '0 10px 0 0',
+    width: '230px'
   },
   headerCell: {
     minWidth: `${cellDimension.width}px`,

--- a/frontend/src/components/course/CourseHeatmap.js
+++ b/frontend/src/components/course/CourseHeatmap.js
@@ -40,9 +40,16 @@ const useStyles = makeStyles(theme => ({
     },
     backgroundColor: '#ebedf0'
   },
+  sideHeaderCell: {
+    boxShadow: '1px 1px 0 0 black'
+  },
   headerCell: {
     minWidth: `${cellDimension.width}px`,
-    minHeight: '100%'
+    minHeight: '100%',
+    boxShadow: '0 1px 0 0 black'
+  },
+  blankHeaderCell: {
+    boxShadow: '1px 1px 0 0 black'
   },
   headerText: {
     minWidth: '100%',
@@ -68,6 +75,28 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(2)
   }
 }))
+
+const BlankHeaderCell = (props) => {
+  const classes = useStyles()
+
+  return (
+    <th className={classes.blankHeaderCell}>
+      <div style={{
+        height: '160px'
+      }}>
+
+        <div style={{
+          position: 'relative',
+          transform: 'rotate(-90deg)',
+          left: '47%',
+          top: '23%'
+
+        }}>Prerequisite</div>
+        <div style={{position:'relative', top: '79%', right: '40%'}}>Target</div>
+      </div>
+    </th>
+  )
+}
 
 const HeaderCell = ({ title }) => {
   const classes = useStyles()
@@ -188,7 +217,7 @@ const CourseHeatmap = ({ workspaceId }) => {
                   <table>
                     <thead>
                       <tr>
-                        <HeaderCell />
+                        <BlankHeaderCell/>
                         {workspaceCourseQuery.data.workspaceById.courses.map(course => (
                           <HeaderCell key={course.id} title={course.name} />
                         ))
@@ -201,7 +230,7 @@ const CourseHeatmap = ({ workspaceId }) => {
                       {
                         workspaceCourseQuery.data.workspaceById.courses.map(fromCourse => (
                           <tr key={`${fromCourse.id}`}>
-                            <th> {fromCourse.name} </th>
+                            <th className={classes.sideHeaderCell}> {fromCourse.name} </th>
                             {
                               workspaceCourseQuery.data.workspaceById.courses.map(toCourse => (
                                 <TableCell workspaceId={workspaceId} minGradVal={0} maxGradVal={maxGradVal} key={`${fromCourse.id}-${toCourse.id}`} fromCourse={fromCourse} toCourse={toCourse} />

--- a/frontend/src/components/course/CourseHeatmap.js
+++ b/frontend/src/components/course/CourseHeatmap.js
@@ -37,11 +37,8 @@ const useStyles = makeStyles(theme => ({
       '& + div': {
         display: 'block'
       }
-    }
-
-  },
-  tableCellContainer: {
-    padding: '1px'
+    },
+    backgroundColor: '#ebedf0'
   },
   headerCell: {
     minWidth: `${cellDimension.width}px`,
@@ -125,7 +122,7 @@ const TableCell = withRouter(({ toCourse, fromCourse, minGradVal, maxGradVal, wo
 
   const mapToGrad = (amount) => {
     const colorStrength = ['#fffff', ...Object.values(pink).slice(0, 9)]
-    let val = (8 / maxGradVal) * (amount)
+    const val = (8 / maxGradVal) * (amount)
     return colorStrength[Math.ceil(val)]
   }
 
@@ -135,7 +132,7 @@ const TableCell = withRouter(({ toCourse, fromCourse, minGradVal, maxGradVal, wo
 
   return (
     <>
-      <td key={`table-${toCourse.id}-${fromCourse.id}`} className={classes.tableCellContainer}>
+      <td key={`table-${toCourse.id}-${fromCourse.id}`}>
         <div className={classes.tableCell} style={{
           backgroundColor: mapToGrad(conceptsLinked)
         }} onClick={navigateToMapper(toCourse.id)}>

--- a/frontend/src/components/course/CourseHeatmap.js
+++ b/frontend/src/components/course/CourseHeatmap.js
@@ -41,12 +41,14 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: '#ebedf0'
   },
   sideHeaderCell: {
-    boxShadow: '1px 1px 0 0 black'
+    boxShadow: '1px 1px 0 0 black',
+    padding: '0 10px 0 0'
   },
   headerCell: {
     minWidth: `${cellDimension.width}px`,
     minHeight: '100%',
-    boxShadow: '0 1px 0 0 black'
+    boxShadow: '0 1px 0 0 black',
+    padding: '0 0 10px 0'
   },
   blankHeaderCell: {
     boxShadow: '1px 1px 0 0 black'
@@ -88,11 +90,11 @@ const BlankHeaderCell = (props) => {
         <div style={{
           position: 'relative',
           transform: 'rotate(-90deg)',
-          left: '47%',
-          top: '23%'
+          left: '44%',
+          top: '26%'
 
         }}>Prerequisite</div>
-        <div style={{position:'relative', top: '79%', right: '40%'}}>Target</div>
+        <div style={{ position: 'relative', top: '76%', right: '36%' }}>Target</div>
       </div>
     </th>
   )
@@ -217,7 +219,7 @@ const CourseHeatmap = ({ workspaceId }) => {
                   <table>
                     <thead>
                       <tr>
-                        <BlankHeaderCell/>
+                        <BlankHeaderCell />
                         {workspaceCourseQuery.data.workspaceById.courses.map(course => (
                           <HeaderCell key={course.id} title={course.name} />
                         ))

--- a/frontend/src/components/course/CourseHeatmap.js
+++ b/frontend/src/components/course/CourseHeatmap.js
@@ -86,7 +86,8 @@ const HeaderCell = ({ title }) => {
           paddingLeft: '5px'
         }}>
           <div style={{
-            wordBreak: 'break-word',
+            overflowWrap: 'break-word',
+            hyphens: 'auto',
             maxWidth: '14ch',
             maxHeight: '38px',
             overflow: 'hidden',

--- a/frontend/src/components/course/CourseHeatmap.js
+++ b/frontend/src/components/course/CourseHeatmap.js
@@ -51,7 +51,9 @@ const useStyles = makeStyles(theme => ({
     padding: '0 0 10px 0'
   },
   blankHeaderCell: {
-    boxShadow: '1px 1px 0 0 black'
+    boxShadow: '1px 1px 0 0 black',
+    minWidth: '150px',
+    minHeight: '150px'
   },
   headerText: {
     minWidth: '100%',
@@ -84,18 +86,15 @@ const BlankHeaderCell = (props) => {
   return (
     <th className={classes.blankHeaderCell}>
       <div style={{
-        height: '160px'
-      }}>
-
-        <div style={{
-          position: 'relative',
-          transform: 'rotate(-90deg)',
-          left: '44%',
-          top: '26%'
-
-        }}>Prerequisite</div>
-        <div style={{ position: 'relative', top: '76%', right: '36%' }}>Target</div>
-      </div>
+        position: 'absolute',
+        transform: 'translate(36px, -30px) rotate(-90deg)',
+        right: '0'
+      }}>Prerequisite</div>
+      <div style={{
+        position: 'absolute',
+        bottom: '2px',
+        right: '65%'
+      }}>Target</div>
     </th>
   )
 }

--- a/frontend/src/components/course/CourseHeatmap.js
+++ b/frontend/src/components/course/CourseHeatmap.js
@@ -43,7 +43,8 @@ const useStyles = makeStyles(theme => ({
   sideHeaderCell: {
     boxShadow: '1px 1px 0 0 black',
     padding: '0 10px 0 0',
-    width: '230px'
+    width: '230px',
+    fontWeight:'normal'
   },
   headerCell: {
     minWidth: `${cellDimension.width}px`,
@@ -88,7 +89,7 @@ const BlankHeaderCell = (props) => {
     <th className={classes.blankHeaderCell}>
       <div style={{
         position: 'absolute',
-        transform: 'translate(36px, -30px) rotate(-90deg)',
+        transform: 'translate(34px, 24px) rotate(-90deg)',
         right: '0'
       }}>Prerequisite</div>
       <div style={{
@@ -123,8 +124,8 @@ const HeaderCell = ({ title }) => {
             maxHeight: '38px',
             overflow: 'hidden',
             textAlign: 'center',
-            textOverflow: 'ellipsis'
-
+            textOverflow: 'ellipsis',
+            fontWeight: 'normal'
           }}>
             {title}
           </div>

--- a/frontend/src/components/course/GuidedCourseTray.js
+++ b/frontend/src/components/course/GuidedCourseTray.js
@@ -31,7 +31,8 @@ const styles = theme => ({
   },
   courseName: {
     maxWidth: '80%',
-    overflowWrap: 'break-word'
+    overflowWrap: 'break-word',
+    hyphens: 'auto'
   },
   cardHeader: {
     paddingBottom: '0px'
@@ -40,7 +41,8 @@ const styles = theme => ({
     maxWidth: '100%'
   },
   title: {
-    overflowWrap: 'break-word'
+    overflowWrap: 'break-word',
+    hyphens: 'auto'
   },
   list: {
     backgroundColor: theme.palette.background.paper,

--- a/frontend/src/components/course/heatmap.css
+++ b/frontend/src/components/course/heatmap.css
@@ -11,9 +11,6 @@ table {
   border-collapse: collapse;
 }
 
-td, th {
-  padding: 0.25em;
-}
 
 thead th {
   position: -webkit-sticky; /* for Safari */

--- a/frontend/src/components/course/heatmap.css
+++ b/frontend/src/components/course/heatmap.css
@@ -25,6 +25,7 @@ tbody th {
   position: sticky;
   left: 0;
   background: #fff;
+  width: 150px;
 }
 
 thead th:first-child {


### PR DESCRIPTION
fixes: #114 
* [x] The scrollable headers could have some kind of color or border
* [x] Somehow label the axes
* [x] The tiles could be slightly tinted even if they don't have any weight to show
* [ ] (optional) Try a view with the concepts of the default course (or chosen course) as the rows, so that one can see which courses are linked to that course and which concepts of that course.