### PR TITLE
Workspace name shown after deselecting project

### DIFF
--- a/frontend/src/views/porting/PortView.js
+++ b/frontend/src/views/porting/PortView.js
@@ -285,11 +285,12 @@ const PortView = () => {
     setLoading(false)
   }
 
+  const handleProjectChange = (event) => {
+    setSelectState({ ...selectState, [event.target.name]: event.target.value, workspaceId: '' })
+  }
+
   const handleChange = (event) => {
-    const newState = event.target.name === 'projectId' && event.target.value === ''
-      ? { ...selectState, [event.target.name]: event.target.value, workspaceId: '' }
-      : { ...selectState, [event.target.name]: event.target.value }
-    setSelectState(newState)
+    setSelectState({ ...selectState, [event.target.name]: event.target.value })
   }
 
   const workspaceOptions = () => {
@@ -330,7 +331,7 @@ const PortView = () => {
               </InputLabel>
               <Select
                 value={selectState.projectId}
-                onChange={handleChange}
+                onChange={handleProjectChange}
                 input={
                   <OutlinedInput
                     labelWidth={projectLabelWidth}

--- a/frontend/src/views/porting/PortView.js
+++ b/frontend/src/views/porting/PortView.js
@@ -286,10 +286,10 @@ const PortView = () => {
   }
 
   const handleChange = (event) => {
-    setSelectState({
-      ...selectState,
-      [event.target.name]: event.target.value
-    })
+    const newState = event.target.name === 'projectId' && event.target.value === ''
+      ? { ...selectState, [event.target.name]: event.target.value, workspaceId: '' }
+      : { ...selectState, [event.target.name]: event.target.value }
+    setSelectState(newState)
   }
 
   const workspaceOptions = () => {


### PR DESCRIPTION
FIX: If one selected a project, then a workspace, then deselected the project the workspaceId would not reset and the "workspace name" field would not be shown