### PR TITLE
Add dev proxy for prisma admin and don't expose prisma port

### DIFF
--- a/development.yml
+++ b/development.yml
@@ -11,6 +11,7 @@ services:
       - 8080:3000
     environment:
       PROXY: http://backend:4000
+      PRISMA_PROXY: http://prisma:4466
     volumes:
       - ./frontend:/concepts/frontend
       - ./backend/src/static/port.schema.json:/concepts/backend/src/static/port.schema.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
   prisma:
     image: prismagraphql/prisma:1.34
     restart: always
-    ports:
-      - 4466:4466
     environment:
       PRISMA_CONFIG: |
         managementApiSecret: yFodXR4mdFErATYsUrBvE4RPBiCUADbdONF6OMH28kA8gU0T6A

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -2,5 +2,12 @@
 const proxy = require('http-proxy-middleware')
 
 const target = process.env.PROXY || require('../package.json').proxy
+const prismaTarget = process.env.PRISMA_PROXY
 
-module.exports = app => app.use(proxy('/graphql', { target, changeOrigin: true }))
+module.exports = app => {
+  app.use(proxy('/graphql', { target, changeOrigin: true }))
+  app.use(proxy('/playground', { target, changeOrigin: true }))
+  if (prismaTarget) {
+    app.use(proxy('/prisma', { target: prismaTarget, pathRewrite: { '^/prisma': '/' } }))
+  }
+}


### PR DESCRIPTION
Expose admin panel as http://localhost:8080/prisma/_admin instead of exposing 4466 directly from prisma

~~Based on #316~~