### PR TITLE
Briefly highlight concept link after creating even if not focused

### DIFF
--- a/frontend/src/views/mapper/ActiveCourse.js
+++ b/frontend/src/views/mapper/ActiveCourse.js
@@ -72,6 +72,7 @@ const ActiveCourse = ({
   onClick,
   addingLink,
   setAddingLink,
+  flashLink,
   toggleFocus,
   urlPrefix
 }) => {
@@ -124,6 +125,7 @@ const ActiveCourse = ({
             focusedConceptIds={focusedConceptIds}
             addingLink={addingLink}
             setAddingLink={setAddingLink}
+            flashLink={flashLink}
             toggleFocus={toggleFocus}
             activeCourseId={course.id}
             workspaceId={workspaceId}

--- a/frontend/src/views/mapper/Course.js
+++ b/frontend/src/views/mapper/Course.js
@@ -58,6 +58,7 @@ const Course = ({
   activeCourseId,
   addingLink,
   setAddingLink,
+  flashLink,
   toggleFocus,
   focusedConceptIds,
   workspaceId,
@@ -128,6 +129,7 @@ const Course = ({
               connectionRef={index === 0 ? connectionRef : undefined}
               addingLink={addingLink}
               setAddingLink={setAddingLink}
+              flashLink={flashLink}
               toggleFocus={toggleFocus}
               focusedConceptIds={focusedConceptIds}
               activeCourseId={activeCourseId}

--- a/frontend/src/views/mapper/PrerequisiteContainer.js
+++ b/frontend/src/views/mapper/PrerequisiteContainer.js
@@ -20,6 +20,7 @@ const PrerequisiteContainer = ({
   focusedConceptIds,
   addingLink,
   setAddingLink,
+  flashLink,
   toggleFocus,
   workspaceId,
   courseId,
@@ -48,6 +49,7 @@ const PrerequisiteContainer = ({
                 focusedConceptIds={focusedConceptIds}
                 addingLink={addingLink}
                 setAddingLink={setAddingLink}
+                flashLink={flashLink}
                 toggleFocus={toggleFocus}
                 activeCourseId={courseId}
                 workspaceId={workspaceId}

--- a/frontend/src/views/mapper/concept/ConceptLink.js
+++ b/frontend/src/views/mapper/concept/ConceptLink.js
@@ -147,21 +147,18 @@ export default class ConceptLink extends Component {
   }
 }
 
-const useLineStyles = makeStyles({
-  linetoPlaceholder: {
+const useStyles = makeStyles({
+  placeholder: {
     display: 'none'
   },
-  linetoHover: {
+  hover: {
     '&:hover': {
       backgroundColor: 'rgba(245, 0, 87, 0.25)'
     }
   },
-  linetoWrapper: {
-    '&:not($linetoActive)': {
+  wrapper: {
+    '&:not($activeWrapper)': {
       pointerEvents: 'none'
-    },
-    '&$linetoActive:before': {
-      borderRightColor: 'red'
     },
     '&:before': {
       content: '""',
@@ -177,22 +174,26 @@ const useLineStyles = makeStyles({
       marginTop: '-7px'
     }
   },
-  linetoLine: {
+  line: {
     position: 'absolute',
     pointerEvents: 'none',
-    borderTop: '3px solid rgba(117, 117, 117, 0.15)',
-    '&$linetoActive': {
-      borderTopColor: '#f50057'
-    }
+    borderTop: '3px solid rgba(117, 117, 117, 0.15)'
   },
-  linetoActive: {}
+  activeLine: {
+    borderTopColor: '#f50057'
+  },
+  activeWrapper: {
+    '&:before': {
+      borderRightColor: 'red'
+    }
+  }
 })
 
 const Line = ({
   x0, y0, x1, y1, from, to, followMouse, within = '', refreshPoints, onContextMenu, linkRef, zIndex,
-  active, attributes, linkId
+  active, attributes, linkId, classes: propClasses
 }) => {
-  const classes = useLineStyles()
+  const classes = useStyles({ classes: propClasses })
   const el = useRef(null)
 
   const dyn = useRef({ x: null, y: null })
@@ -320,24 +321,19 @@ const Line = ({
   // React component is removed. This is because we manually
   // move the rendered DOM element after creation.
   return (
-    <div
-      className={classes.linetoPlaceholder} data-link-from={from} data-link-to={to} {...attributes}
-    >
+    <div className={classes.placeholder} data-link-from={from} data-link-to={to} {...attributes}>
       <div
-        className={`${classes.linetoWrapper} ${active && !followMouse ? classes.linetoActive : ''}`}
+        className={`${classes.wrapper} ${active && !followMouse ? classes.activeWrapper : ''}`}
         ref={elCallback} style={wrapperStyle}
       >
         {(active && !followMouse) &&
           <div
-            style={hoverAreaStyle} className={classes.linetoHover}
+            style={hoverAreaStyle} className={classes.hover}
             onContextMenu={evt => onContextMenu(evt, linkId)}
             onClick={evt => onContextMenu(evt, linkId)}
           />
         }
-        <div
-          style={innerStyle}
-          className={`${classes.linetoLine} ${active ? classes.linetoActive : ''}`}
-        />
+        <div style={innerStyle} className={`${classes.line} ${active ? classes.activeLine : ''}`} />
       </div>
     </div>
   )


### PR DESCRIPTION
~~Depends on #333 (change base to master after merging)~~ done

When drawing a link between inactive concepts, the link is focused briefly and then fades out. When drawing a link from or to an active concept, the link stays focused like before.

![output](https://user-images.githubusercontent.com/4224639/65667379-4ae06d80-e048-11e9-815f-cec2069c9973.gif)
