### PR TITLE
Add concept mapper view

### DIFF
--- a/backend/src/resolvers/Mutation/Concept.js
+++ b/backend/src/resolvers/Mutation/Concept.js
@@ -98,7 +98,7 @@ export const createConcept = async (root, {
     official: Boolean(official),
     frozen: Boolean(frozen),
     course: { connect: { id: courseId } },
-    tags: { connect: await createMissingTags(tags, workspaceId, context, 'conceptTags') }
+    tags: tags && { connect: await createMissingTags(tags, workspaceId, context, 'conceptTags') }
   })
 
   if (createdConcept) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react-apollo-hooks": "^0.4.5",
     "react-app-rewired": "^2.1.3",
     "react-dom": "^16.8.6",
+    "react-draggable": "^4.1.0",
     "react-measure": "^2.3.0",
     "react-modal": "^3.8.1",
     "react-router-dom": "^5.0.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,6 +22,7 @@ import NotFoundView from './views/error/NotFoundView'
 import PointGroupsView from './views/project/PointGroupsView'
 import MembersView from './views/members/MembersView'
 import UserView from './views/user/UserView'
+import ConceptMapperView from './views/conceptmapper/ConceptMapperView'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -56,6 +57,14 @@ const workspaceRouter = (prefix) => <>
     }
   />
   <Route
+    exact path={`${prefix}/:wid/conceptmapper/:cid`}
+    render={({ match }) =>
+      <ConceptMapperView
+        workspaceId={match.params.wid} courseId={match.params.cid} urlPrefix={prefix}
+      />
+    }
+  />
+  <Route
     exact path={`${prefix}/:wid/mapper/:cid`}
     render={({ match }) =>
       <CourseMapperView
@@ -67,7 +76,7 @@ const workspaceRouter = (prefix) => <>
   <Route exact path={`${prefix}/:wid/members`} render={({ match: { params: { wid } } }) =>
     <MembersView workspaceId={wid} />} />
   <Route
-    exact path={`${prefix}/:wid/:page(mapper|graph|heatmap|manager|members)/:cid?`}
+    exact path={`${prefix}/:wid/:page(conceptmapper|mapper|graph|heatmap|manager|members)/:cid?`}
     render={({ match: { params: { wid, cid, page } } }) =>
       <WorkspaceNavBar urlPrefix={prefix} workspaceId={wid} courseId={cid} page={page} />
     }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -33,7 +33,11 @@ const useStyles = makeStyles(() => ({
     gridTemplate: `"navbar"  48px
                    "content" auto
                    "bottom-navbar" 56px
-                   / 100vw`
+                   / 100vw`,
+    pointerEvents: 'none',
+    '& > *': {
+      pointerEvents: 'initial'
+    }
   }
 }))
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -55,10 +55,8 @@ const workspaceRouter = (prefix) => <>
     />}
   />
   <Route
-    exact path={`${prefix}/:wid/mapper`}
-    render={({ match, location }) =>
-      <MapperRedirectView workspaceId={match.params.wid} urlPrefix={prefix} location={location} />
-    }
+    exact path={`${prefix}/:wid/(concept)?mapper`}
+    render={({ match }) => <MapperRedirectView workspaceId={match.params.wid} urlPrefix={prefix} />}
   />
   <Route
     exact path={`${prefix}/:wid/conceptmapper/:cid`}

--- a/frontend/src/components/BaseWorkspaceList.js
+++ b/frontend/src/components/BaseWorkspaceList.js
@@ -208,13 +208,12 @@ This will change which template is cloned by users.`)
     history.push(`${urlPrefix}/${workspaceId}/manager`)
   }
 
-  const handleNavigateMapper = () => {
+  const handleNavigateCourseMapper = () => {
     history.push(`${urlPrefix}/${menu.workspace.id}/mapper`)
   }
 
   const handleNavigateConceptMapper = () => {
-    // TODO
-    window.alert('Entering mapper from workspace list is not yet implemented')
+    history.push(`${urlPrefix}/${menu.workspace.id}/conceptmapper`)
   }
 
   const handleNavigateHeatmap = () => {
@@ -260,7 +259,7 @@ This will change which template is cloned by users.`)
         ))
       }</List>
       <Menu anchorEl={menu.anchor} open={menu.open} onClose={handleMenuClose}>
-        <MenuItem aria-label='Mapper' onClick={handleNavigateMapper}>
+        <MenuItem aria-label='Mapper' onClick={handleNavigateCourseMapper}>
           <ListItemIcon>
             <AccountTreeIcon />
           </ListItemIcon>

--- a/frontend/src/components/BaseWorkspaceList.js
+++ b/frontend/src/components/BaseWorkspaceList.js
@@ -7,7 +7,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import {
   Add as AddIcon, Edit as EditIcon, Delete as DeleteIcon, GridOn as GridOnIcon, Share as ShareIcon,
   MoreVert as MoreVertIcon, CloudDownload as CloudDownloadIcon, Shuffle as ShuffleIcon,
-  RadioButtonChecked, RadioButtonUnchecked
+  AccountTree as AccountTreeIcon, RadioButtonChecked, RadioButtonUnchecked
 } from '@material-ui/icons'
 
 import { Privilege } from '../lib/permissions'
@@ -212,6 +212,11 @@ This will change which template is cloned by users.`)
     history.push(`${urlPrefix}/${menu.workspace.id}/mapper`)
   }
 
+  const handleNavigateConceptMapper = () => {
+    // TODO
+    window.alert('Entering mapper from workspace list is not yet implemented')
+  }
+
   const handleNavigateHeatmap = () => {
     history.push(`${urlPrefix}/${menu.workspace.id}/heatmap`)
   }
@@ -257,9 +262,15 @@ This will change which template is cloned by users.`)
       <Menu anchorEl={menu.anchor} open={menu.open} onClose={handleMenuClose}>
         <MenuItem aria-label='Mapper' onClick={handleNavigateMapper}>
           <ListItemIcon>
+            <AccountTreeIcon />
+          </ListItemIcon>
+          Course Mapper
+        </MenuItem>
+        <MenuItem aria-label='Mapper' onClick={handleNavigateConceptMapper}>
+          <ListItemIcon>
             <ShuffleIcon />
           </ListItemIcon>
-          Mapper
+          Concept Mapper
         </MenuItem>
         <MenuItem aria-label='Heatmap' onClick={handleNavigateHeatmap}>
           <ListItemIcon>

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -26,7 +26,7 @@ const Link = props => <MaterialLink {...props} component={RouterLink} />
 const useStyles = makeStyles(() => ({
   root: {
     gridArea: 'navbar',
-    zIndex: 2
+    zIndex: 10
   },
   breadcrumbs: {
     flexGrow: 1,

--- a/frontend/src/components/WorkspaceNavBar.js
+++ b/frontend/src/components/WorkspaceNavBar.js
@@ -7,7 +7,8 @@ import {
 import {
   Shuffle as ShuffleIcon, GridOn as GridOnIcon, DeviceHub as DeviceHubIcon, Group as GroupIcon,
   CloudDownload as CloudDownloadIcon, Delete as DeleteIcon, Edit as EditIcon, Share as ShareIcon,
-  MoreVert as MoreVertIcon, VerticalSplit as VerticalSplitIcon, HelpOutline as HelpIcon
+  MoreVert as MoreVertIcon, VerticalSplit as VerticalSplitIcon, HelpOutline as HelpIcon,
+  AccountTree as AccountTreeIcon
 } from '@material-ui/icons'
 
 import { Privilege } from '../lib/permissions'
@@ -129,7 +130,9 @@ const WorkspaceNavBar = ({ page, workspaceId, courseId, urlPrefix }) => {
   }
 
   const onChange = (event, newPage) => {
-    const cid = courseId && (newPage === 'mapper' || newPage === 'manager') ? `/${courseId}` : ''
+    const cid = courseId
+      && (newPage === 'mapper' || newPage === 'conceptmapper' || newPage === 'manager')
+      ? `/${courseId}` : ''
     history.push(`${urlPrefix}/${workspaceId}/${newPage}${cid}`)
   }
 
@@ -142,7 +145,9 @@ const WorkspaceNavBar = ({ page, workspaceId, courseId, urlPrefix }) => {
       <div className={classes.leftPlaceholder} />
       <BottomNavigation showLabels value={page} onChange={onChange} className={classes.navbar}>
         <BottomNavigationAction value='manager' label='Manager' icon={<VerticalSplitIcon />} />
-        <BottomNavigationAction value='mapper' label='Course Mapper' icon={<ShuffleIcon />} />
+        <BottomNavigationAction value='mapper' label='Course Mapper' icon={<AccountTreeIcon />} />
+        <BottomNavigationAction
+          value='conceptmapper' label='Concept Mapper' icon={<ShuffleIcon />} />
         <BottomNavigationAction value='graph' label='Graph' icon={<DeviceHubIcon />} />
         <BottomNavigationAction value='heatmap' label='Heatmap' icon={<GridOnIcon />} />
         {isOwner &&

--- a/frontend/src/components/WorkspaceNavBar.js
+++ b/frontend/src/components/WorkspaceNavBar.js
@@ -25,7 +25,8 @@ const useStyles = makeStyles({
   root: {
     gridArea: 'bottom-navbar',
     display: 'flex',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
+    zIndex: 10
   },
   leftPlaceholder: {
     width: '56px',

--- a/frontend/src/dialogs/concept/useEditConceptDialog.js
+++ b/frontend/src/dialogs/concept/useEditConceptDialog.js
@@ -46,10 +46,10 @@ const useEditConceptDialog = (workspaceId, isStaff) => {
   }) => openDialog({
     mutation: updateConcept,
     createOptimisticResponse: (args) => createOptimisticResponse({ ...args, level, course }),
-    type: 'Concept',
+    type: level.toTitleCase(),
     requiredVariables: { id, position, official: false },
     actionText: 'Save',
-    title: 'Edit concept',
+    title: `Edit ${level.toLowerCase()}`,
     fields: [{
       name: 'name',
       required: true,

--- a/frontend/src/graphql/Query/Course.js
+++ b/frontend/src/graphql/Query/Course.js
@@ -58,6 +58,7 @@ query courseById($id: ID!) {
       }
     }
     conceptOrder
+    objectiveOrder
     concepts {
       id
       name

--- a/frontend/src/graphql/Query/Course.js
+++ b/frontend/src/graphql/Query/Course.js
@@ -37,15 +37,6 @@ query courseById($id: ID!) {
 `
 
 const COURSE_BY_ID_WITH_LINKS = gql`
-query workspaceById($workspaceId: ID!) {
-  workspaceById(id: $workspaceId) {
-    courses {
-      id
-      name
-    }
-  }
-}
-
 query courseById($id: ID!) {
   courseById(id: $id) {
     id
@@ -57,6 +48,13 @@ query courseById($id: ID!) {
       name
       type
       priority
+    }
+    workspace {
+      id
+      courses {
+        id
+        name
+      }
     }
     conceptOrder
     concepts {

--- a/frontend/src/graphql/Query/Course.js
+++ b/frontend/src/graphql/Query/Course.js
@@ -37,6 +37,15 @@ query courseById($id: ID!) {
 `
 
 const COURSE_BY_ID_WITH_LINKS = gql`
+query workspaceById($workspaceId: ID!) {
+  workspaceById(id: $workspaceId) {
+    courses {
+      id
+      name
+    }
+  }
+}
+
 query courseById($id: ID!) {
   courseById(id: $id) {
     id

--- a/frontend/src/graphql/Query/Course.js
+++ b/frontend/src/graphql/Query/Course.js
@@ -36,6 +36,53 @@ query courseById($id: ID!) {
 }
 `
 
+const COURSE_BY_ID_WITH_LINKS = gql`
+query courseById($id: ID!) {
+  courseById(id: $id) {
+    id
+    name
+    official
+    frozen
+    tags {
+      id
+      name
+      type
+      priority
+    }
+    conceptOrder
+    concepts {
+      id
+      name
+      description
+      level
+      position
+      official
+      frozen
+      tags {
+        id
+        name
+        type
+        priority
+      }
+      course {
+        id
+      }
+      linksToConcept {
+        id
+        official
+        frozen
+        from {
+          course {
+            id
+          }
+          id
+        }
+      }
+    }
+  }
+}
+`
+
 const LINKS_IN_COURSE = gql`
 query linksInCourse($courseId: ID!) {
   linksInCourse: courseById(id: $courseId) {
@@ -120,5 +167,6 @@ export {
   COURSE_BY_ID,
   COURSE_PREREQUISITES,
   COURSE_PREREQ_FRAGMENT,
-  LINKS_IN_COURSE
+  LINKS_IN_COURSE,
+  COURSE_BY_ID_WITH_LINKS
 }

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -106,7 +106,7 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
   })
 
   const courseQuery = useQuery(COURSE_BY_ID_WITH_LINKS, {
-    variables: { id: courseId }
+    variables: { id: courseId, workspaceId }
   })
 
   const updateSelection = (axisKey, posKey, lenKey, value, offset) => {

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -25,6 +25,22 @@ const useStyles = makeStyles({
     transform: 'translate(0, 0)',
     transformOrigin: '0 0'
   },
+  toolbar: {
+    position: 'fixed',
+    left: 0,
+    top: '48px',
+    bottom: '58px',
+    width: '250px',
+    backgroundColor: 'white'
+  },
+  objectives: {
+    position: 'fixed',
+    right: 0,
+    top: '48px',
+    bottom: '58px',
+    width: '300px',
+    backgroundColor: 'white'
+  },
   selection: {
     position: 'absolute',
     backgroundColor: 'rgba(255, 0, 0, .25)',
@@ -203,15 +219,10 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
 
     const mouseX = evt.pageX - main.current.offsetLeft
     const mouseY = evt.pageY - main.current.offsetTop
-    pan.current.x += mouseX
-    pan.current.y += mouseY
-    pan.current.x /= pan.current.zoom
-    pan.current.y /= pan.current.zoom
+    const oldZoom = pan.current.zoom
     pan.current.zoom = linearToLog(pan.current.linearZoom)
-    pan.current.x *= pan.current.zoom
-    pan.current.y *= pan.current.zoom
-    pan.current.x -= mouseX
-    pan.current.y -= mouseY
+    pan.current.x = ((pan.current.x + mouseX) / oldZoom * pan.current.zoom) - mouseX
+    pan.current.y = ((pan.current.y + mouseY) / oldZoom * pan.current.zoom) - mouseY
 
     main.current.style.transform =
       `translate(${-pan.current.x}px, ${-pan.current.y}px) scale(${pan.current.zoom})`
@@ -353,9 +364,9 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
     y1: -58
   }
 
-  return (
+  return <>
     <main className={classes.root} ref={main}>
-      {course.concepts.flatMap(concept => [
+      {course.concepts.flatMap(concept => concept.level === 'CONCEPT' ? [
         <ConceptNode
           key={concept.id} workspaceId={workspaceId} concept={concept} pan={pan}
           openMenu={openConceptMenu(concept.id)} closeMenu={closeConceptMenu(concept.id)}
@@ -370,8 +381,7 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
           fromConceptId={concept.id} toConceptId={link.from.id}
           fromAnchor='center middle' toAnchor='center middle'
         />)
-      ])}
-      <div ref={selectionRef} className={classes.selection} />
+      ] : [])}
       {adding && <ConceptNode
         isNew concept={{ id: 'new', name: '', position: adding }}
         concepts={concepts} selected={selected}
@@ -381,29 +391,38 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
         active within={document.body}
         followMouse from={`concept-${addingLink}`} to={`concept-${addingLink}`}
       />}
+      <div ref={selectionRef} className={classes.selection} />
       <div id='concept-mapper-link-container' />
-
-      <Menu
-        keepMounted anchorReference='anchorPosition' anchorPosition={menu.anchor}
-        open={menu.open === 'concept'} onClose={closeMenu}
-      >
-        <MenuItem onClick={menuAddLink}>Add link</MenuItem>
-        <MenuItem onClick={menuDeleteConcept}>Delete concept</MenuItem>
-      </Menu>
-      <Menu
-        keepMounted anchorReference='anchorPosition' anchorPosition={menu.anchor}
-        open={menu.open === 'concept-link'} onClose={closeMenu}
-      >
-        <MenuItem onClick={menuDeleteLink}>Delete link</MenuItem>
-      </Menu>
-      <Menu
-        keepMounted anchorReference='anchorPosition' anchorPosition={menu.anchor}
-        open={menu.open === 'background'} onClose={closeMenu}
-      >
-        <MenuItem onClick={menuAddConcept}>Add concept</MenuItem>
-      </Menu>
     </main>
-  )
+
+    <section className={classes.toolbar}>
+
+    </section>
+
+    <section className={classes.objectives}>
+
+    </section>
+
+    <Menu
+      keepMounted anchorReference='anchorPosition' anchorPosition={menu.anchor}
+      open={menu.open === 'concept'} onClose={closeMenu}
+    >
+      <MenuItem onClick={menuAddLink}>Add link</MenuItem>
+      <MenuItem onClick={menuDeleteConcept}>Delete concept</MenuItem>
+    </Menu>
+    <Menu
+      keepMounted anchorReference='anchorPosition' anchorPosition={menu.anchor}
+      open={menu.open === 'concept-link'} onClose={closeMenu}
+    >
+      <MenuItem onClick={menuDeleteLink}>Delete link</MenuItem>
+    </Menu>
+    <Menu
+      keepMounted anchorReference='anchorPosition' anchorPosition={menu.anchor}
+      open={menu.open === 'background'} onClose={closeMenu}
+    >
+      <MenuItem onClick={menuAddConcept}>Add concept</MenuItem>
+    </Menu>
+  </>
 }
 
 export default ConceptMapperView

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -30,12 +30,7 @@ const useStyles = makeStyles({
     transformOrigin: '0 0'
   },
   toolbar: {
-    position: 'fixed',
-    left: 0,
-    top: '48px',
-    bottom: '58px',
-    width: '250px',
-    backgroundColor: 'white'
+
   },
   objectives: {
     position: 'fixed',
@@ -282,6 +277,7 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
   }
 
   const course = courseQuery.data.courseById
+  const courses = courseQuery.data.workspaceById.courses
 
   const submitExistingConcept = id => ({ name, position }) => updateConcept({
     variables: {

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { useMutation, useQuery } from 'react-apollo-hooks'
 import { makeStyles } from '@material-ui/core/styles'
-import { Menu, MenuItem } from '@material-ui/core'
+import { Menu, MenuItem, InputBase, Select } from '@material-ui/core'
+import useRouter from '../../lib/useRouter'
 
 import { COURSE_BY_ID_WITH_LINKS } from '../../graphql/Query'
 import NotFoundView from '../error/NotFoundView'
@@ -30,7 +31,9 @@ const useStyles = makeStyles({
     transformOrigin: '0 0'
   },
   toolbar: {
-
+    position: 'fixed',
+    top: '60px',
+    left: '10px'
   },
   objectives: {
     position: 'fixed',
@@ -62,7 +65,7 @@ const linearToLog = position =>
 const logToLinear = value =>
   ((Math.log(value) - sliderMinLog) / sliderScale) + sliderMinLinear
 
-const ConceptMapperView = ({ workspaceId, courseId }) => {
+const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
   const [adding, setAdding] = useState(null)
   const [addingLink, setAddingLink] = useState(null)
   const addingLinkRef = useRef()
@@ -76,6 +79,9 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
   const main = useRef()
   const root = document.getElementById('root')
   const classes = useStyles()
+
+  const { history } = useRouter()
+  const [courseSelectOpen, setCourseSelectOpen] = useState(false)
 
   useUpdatingSubscription('workspace', 'update', {
     variables: { workspaceId }
@@ -277,7 +283,7 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
   }
 
   const course = courseQuery.data.courseById
-  const courses = courseQuery.data.workspaceById.courses
+  const courses = courseQuery.data.courseById.workspace.courses
 
   const submitExistingConcept = id => ({ name, position }) => updateConcept({
     variables: {
@@ -399,7 +405,22 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
     </main>
 
     <section className={classes.toolbar}>
-
+        <Select
+          open={courseSelectOpen}
+          value={course.id}
+          MenuProps={{
+            MenuListProps: {
+              onMouseLeave: () => setCourseSelectOpen(false)
+            }
+          }}
+          onMouseEnter={() => setCourseSelectOpen(true)}
+          input={<InputBase/>}
+          onChange={evt => history.push(`${urlPrefix}/${workspaceId}/conceptmapper/${evt.target.value}`)}
+        >
+          {courses.map(course =>
+            <MenuItem key={course.id} value={course.id}>{course.name}</MenuItem>
+          )}
+        </Select>
     </section>
 
     <section className={classes.objectives}>

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -176,6 +176,11 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
 
   const mouseWheel = evt => {
     pan.current.linearZoom -= evt.deltaY
+    if (pan.current.linearZoom < sliderMinLinear) {
+      pan.current.linearZoom = sliderMinLinear
+    } else if (pan.current.linearZoom > sliderMaxLinear) {
+      pan.current.linearZoom = sliderMaxLinear
+    }
     pan.current.x /= pan.current.zoom
     pan.current.y /= pan.current.zoom
     pan.current.zoom = linearToLog(pan.current.linearZoom)

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -200,11 +200,15 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
     } else if (pan.current.linearZoom > sliderMaxLinear) {
       pan.current.linearZoom = sliderMaxLinear
     }
-    pan.current.x /= pan.current.zoom
-    pan.current.y /= pan.current.zoom
+
+    const w = main.current.offsetWidth
+    const h = main.current.offsetHeight
+    pan.current.x = (pan.current.x + (w / 2)) / pan.current.zoom
+    pan.current.y = (pan.current.y + (h / 2)) / pan.current.zoom
     pan.current.zoom = linearToLog(pan.current.linearZoom)
-    pan.current.x *= pan.current.zoom
-    pan.current.y *= pan.current.zoom
+    pan.current.x = (pan.current.x * pan.current.zoom) - (w / 2)
+    pan.current.y = (pan.current.y * pan.current.zoom) - (h / 2)
+
     main.current.style.transform =
       `translate(${-pan.current.x}px, ${-pan.current.y}px) scale(${pan.current.zoom})`
   }

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -413,7 +413,7 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
               onMouseLeave: () => setCourseSelectOpen(false)
             }
           }}
-          onMouseEnter={() => setCourseSelectOpen(true)}
+          onClick={() => setCourseSelectOpen(true)}
           input={<InputBase/>}
           onChange={evt => {
             history.push(`${urlPrefix}/${workspaceId}/conceptmapper/${evt.target.value}`)

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -1,0 +1,125 @@
+import React, { useState, useRef } from 'react'
+import { useQuery } from 'react-apollo-hooks'
+import { makeStyles } from '@material-ui/core/styles'
+
+import { COURSE_BY_ID_WITH_LINKS } from '../../graphql/Query'
+import NotFoundView from '../error/NotFoundView'
+import LoadingBar from '../../components/LoadingBar'
+import ConceptNode from './ConceptNode'
+import { ConceptLink } from '../coursemapper/concept'
+
+const useStyles = makeStyles({
+  root: {
+    gridArea: 'content',
+    position: 'relative',
+    userSelect: 'none'
+  },
+  selection: {
+    position: 'absolute',
+    backgroundColor: 'rgba(255, 0, 0, .25)',
+    border: '4px solid red'
+  },
+  selectedConcept: {
+    border: '2px solid red',
+    padding: '4px'
+  }
+})
+
+const ConceptMapperView = ({ courseId, urlPrefix }) => {
+  const selected = useRef(new Set())
+  const concepts = useRef({})
+  const [selecting, setSelecting] = useState(null)
+  const selection = useRef({})
+  const selectionRef = useRef()
+  const main = useRef()
+  const classes = useStyles()
+
+  const courseQuery = useQuery(COURSE_BY_ID_WITH_LINKS, {
+    variables: { id: courseId }
+  })
+
+  if (courseQuery.error) {
+    return <NotFoundView message='Course not found' />
+  } else if (!courseQuery.data.courseById) {
+    return <LoadingBar id='course-view' />
+  }
+
+  const course = courseQuery.data.courseById
+
+  const startSelect = evt => {
+    if (evt.target !== main.current || evt.button !== 0) {
+      return
+    }
+    const x = evt.pageX - main.current.offsetLeft
+    const y = evt.pageY - main.current.offsetTop
+    selection.current.left = x
+    selection.current.top = y
+    selection.current.right = main.current.offsetWidth - x
+    selection.current.bottom = main.current.offsetHeight - y
+    setSelecting({ x, y })
+  }
+
+  const updateSelection = (key, a, b, value, offset) => {
+    if (value > selecting[key]) {
+      selection.current[a] = selecting[key]
+      selection.current[b] = offset - value
+    } else {
+      selection.current[a] = value
+      selection.current[b] = offset - selecting[key]
+    }
+    selectionRef.current.style[a] = `${selection.current[a]}px`
+    selectionRef.current.style[b] = `${selection.current[b]}px`
+  }
+
+  const updateSelected = () => {
+    const sel = selection.current
+    const selLeftEnd = main.current.offsetWidth - sel.right
+    const selTopEnd = main.current.offsetHeight - sel.bottom
+    for (const [id, state] of Object.entries(concepts.current)) {
+      if (state.x >= sel.left && state.x + state.width <= selLeftEnd
+          && state.y >= sel.top && state.y + state.height <= selTopEnd) {
+        selected.current.add(id)
+        state.node.current.classList.add(classes.selectedConcept)
+      } else {
+        selected.current.delete(id)
+        state.node.current.classList.remove(classes.selectedConcept)
+      }
+    }
+  }
+
+  const select = evt => {
+    if (!selecting || evt.button !== 0) {
+      return
+    }
+    updateSelection('x', 'left', 'right',
+      evt.pageX - main.current.offsetLeft, main.current.offsetWidth)
+    updateSelection('y', 'top', 'bottom',
+      evt.pageY - main.current.offsetTop, main.current.offsetHeight)
+    updateSelected()
+  }
+
+  const stopSelect = () => {
+    selection.current = {}
+    setSelecting(null)
+  }
+
+  return <main
+    className={classes.root} ref={main}
+    onMouseDown={startSelect} onMouseMove={select} onMouseUp={stopSelect}
+  >
+    {course.concepts.flatMap(concept => [
+      <ConceptNode key={concept.id} concept={concept} concepts={concepts} selected={selected} />,
+      ...concept.linksToConcept.map(link => <ConceptLink
+        key={link.id} delay={1} active linkId={link.id}
+        from={`concept-${concept.id}`} to={`concept-${link.from.id}`}
+        fromConceptId={concept.id} toConceptId={link.from.id}
+        fromAnchor='center middle' toAnchor='center middle'
+      />)
+    ])}
+    {selecting && <div
+      ref={selectionRef} className={classes.selection} style={{ ...selection.current }}
+    /> }
+  </main>
+}
+
+export default ConceptMapperView

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -16,6 +16,10 @@ import {
   UPDATE_CONCEPT
 } from '../../graphql/Mutation'
 import cache from '../../apollo/update'
+import {
+  useManyUpdatingSubscriptions,
+  useUpdatingSubscription
+} from '../../apollo/useUpdatingSubscription'
 
 const useStyles = makeStyles({
   root: {
@@ -77,6 +81,14 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
   const main = useRef()
   const root = document.getElementById('root')
   const classes = useStyles()
+
+  useUpdatingSubscription('workspace', 'update', {
+    variables: { workspaceId }
+  })
+
+  useManyUpdatingSubscriptions(['course', 'concept'], ['create', 'delete', 'update'], {
+    variables: { workspaceId }
+  })
 
   const createConcept = useMutation(CREATE_CONCEPT, {
     update: cache.createConceptUpdate(workspaceId)

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
     gridArea: 'content',
     position: 'relative',
     userSelect: 'none',
-    transform: 'translateX(0) translateY(0)',
+    transform: 'translate(0, 0)',
     transformOrigin: '0 0'
   },
   selection: {
@@ -153,7 +153,7 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
       pan.current.y -= evt.movementY
       pan.current.x -= evt.movementX
       main.current.style.transform =
-        `translateX(${-pan.current.x}px) translateY(${-pan.current.y}px) scale(${pan.current.zoom})`
+        `translate(${-pan.current.x}px, ${-pan.current.y}px) scale(${pan.current.zoom})`
     } else if (selection.current) {
       updateSelection('x', 'left', 'width',
         evt.pageX - main.current.offsetLeft,
@@ -176,16 +176,20 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
 
   const mouseWheel = evt => {
     pan.current.linearZoom -= evt.deltaY
+    pan.current.x /= pan.current.zoom
+    pan.current.y /= pan.current.zoom
     pan.current.zoom = linearToLog(pan.current.linearZoom)
+    pan.current.x *= pan.current.zoom
+    pan.current.y *= pan.current.zoom
     main.current.style.transform =
-      `translateX(${-pan.current.x}px) translateY(${-pan.current.y}px) scale(${pan.current.zoom})`
+      `translate(${-pan.current.x}px, ${-pan.current.y}px) scale(${pan.current.zoom})`
   }
 
   const doubleClick = evt => {
     if (evt.target === main.current || evt.target === root) {
       setAdding({
-        x: evt.pageX - main.current.offsetLeft + pan.current.x - 100,
-        y: evt.pageY - main.current.offsetTop + pan.current.y - 17
+        x: ((evt.pageX - main.current.offsetLeft + pan.current.x) / pan.current.zoom) - 100,
+        y: ((evt.pageY - main.current.offsetTop + pan.current.y) / pan.current.zoom) - 17
       })
     }
   }

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -55,13 +55,10 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
 
   const doubleClick = evt => {
     if (evt.target === main.current) {
-      setAdding([{
+      setAdding({
         x: evt.pageX - main.current.offsetLeft - 100,
         y: evt.pageY - main.current.offsetTop - 15
-      }, {
-        width: 200,
-        height: 30
-      }])
+      })
     }
   }
 
@@ -99,10 +96,10 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
       if (state.x >= sel.left && state.x + state.width <= selLeftEnd
           && state.y >= sel.top && state.y + state.height <= selTopEnd) {
         selected.current.add(id)
-        state.node.current.classList.add('selected')
+        state.node.classList.add('selected')
       } else {
         selected.current.delete(id)
-        state.node.current.classList.remove('selected')
+        state.node.classList.remove('selected')
       }
     }
   }

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -52,9 +52,6 @@ const useStyles = makeStyles({
       marginTop: '16px'
     }
   },
-  objectiveList: {
-    flex: 1
-  },
   button: {},
   toolbar: {
     position: 'fixed',
@@ -88,8 +85,12 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
   const [{ user }] = useLoginStateValue()
 
   const [adding, setAdding] = useState(null)
-  const [addingLink, setAddingLink] = useState(null)
+  const [addingLink, setAddingLinkState] = useState(null)
   const addingLinkRef = useRef()
+  const setAddingLink = val => {
+    setAddingLinkState(val)
+    addingLinkRef.current = val
+  }
   const [menu, setMenu] = useState({ open: false })
   const panning = useRef(false)
   const pan = useRef({ x: 0, y: 0, zoom: 1, linearZoom: logToLinear(1) })
@@ -171,7 +172,6 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
       }
     })
     setAddingLink(null)
-    addingLinkRef.current = null
   }
 
   const mouseDown = evt => {
@@ -179,14 +179,14 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
       return
     }
     if (evt.target !== main.current && evt.target !== root) {
-      if (addingLinkRef.current && evt.target.hasAttribute('data-concept-id')) {
-        finishAddingLink(evt.target.getAttribute('data-concept-id'))
+      const conceptRoot = evt.target.closest('.concept-root')
+      if (addingLinkRef.current && conceptRoot?.hasAttribute('data-concept-id')) {
+        finishAddingLink(conceptRoot.getAttribute('data-concept-id'))
       }
       return
     }
     if (addingLinkRef.current) {
       setAddingLink(null)
-      addingLinkRef.current = null
     }
     if (evt.shiftKey) {
       const x = evt.pageX - main.current.offsetLeft
@@ -358,7 +358,6 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
 
   const menuAddLink = () => {
     setAddingLink(menu.id)
-    addingLinkRef.current = menu.id
     closeMenu()
   }
 
@@ -433,6 +432,7 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
     <section className={classes.objectives}>
       <ObjectiveList
         openMenu={openMenu} closeMenu={closeMenuById} className={classes.objectiveList}
+        order={course.objectiveOrder} workspaceId={workspaceId}
         concepts={course.concepts.filter(concept => concept.level === 'OBJECTIVE')}
       />
       <Button

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -85,13 +85,14 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
     const selLeftEnd = sel.left + sel.width
     const selTopEnd = sel.top + sel.height
     for (const [id, state] of Object.entries(concepts.current)) {
+      if (!state.node) continue
       if (state.x >= sel.left && state.x + state.width <= selLeftEnd
         && state.y >= sel.top && state.y + state.height <= selTopEnd) {
         selected.current.add(id)
-        state.node?.classList.add('selected')
+        state.node.classList.add('selected')
       } else {
         selected.current.delete(id)
-        state.node?.classList.remove('selected')
+        state.node.classList.remove('selected')
       }
     }
   }
@@ -164,6 +165,7 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
       window.removeEventListener('mousemove', mouseMove)
       window.removeEventListener('mouseup', mouseUp)
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   if (courseQuery.error) {

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -415,7 +415,10 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
           }}
           onMouseEnter={() => setCourseSelectOpen(true)}
           input={<InputBase/>}
-          onChange={evt => history.push(`${urlPrefix}/${workspaceId}/conceptmapper/${evt.target.value}`)}
+          onChange={evt => {
+            history.push(`${urlPrefix}/${workspaceId}/conceptmapper/${evt.target.value}`)
+            setCourseSelectOpen(false)
+          }}
         >
           {courses.map(course =>
             <MenuItem key={course.id} value={course.id}>{course.name}</MenuItem>

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -201,13 +201,17 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
       pan.current.linearZoom = sliderMaxLinear
     }
 
-    const w = main.current.offsetWidth
-    const h = main.current.offsetHeight
-    pan.current.x = (pan.current.x + (w / 2)) / pan.current.zoom
-    pan.current.y = (pan.current.y + (h / 2)) / pan.current.zoom
+    const mouseX = evt.pageX - main.current.offsetLeft
+    const mouseY = evt.pageY - main.current.offsetTop
+    pan.current.x += mouseX
+    pan.current.y += mouseY
+    pan.current.x /= pan.current.zoom
+    pan.current.y /= pan.current.zoom
     pan.current.zoom = linearToLog(pan.current.linearZoom)
-    pan.current.x = (pan.current.x * pan.current.zoom) - (w / 2)
-    pan.current.y = (pan.current.y * pan.current.zoom) - (h / 2)
+    pan.current.x *= pan.current.zoom
+    pan.current.y *= pan.current.zoom
+    pan.current.x -= mouseX
+    pan.current.y -= mouseY
 
     main.current.style.transform =
       `translate(${-pan.current.x}px, ${-pan.current.y}px) scale(${pan.current.zoom})`

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -74,7 +74,6 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
   const [menu, setMenu] = useState({ open: false })
   const panning = useRef(false)
   const pan = useRef({ x: 0, y: 0, zoom: 1, linearZoom: logToLinear(1) })
-  const edge = useRef({ left: 0, top: 0, right: 0, bottom: 0 })
   const selected = useRef(new Set())
   const concepts = useRef({})
   const selection = useRef(null)
@@ -114,36 +113,6 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
   const courseQuery = useQuery(COURSE_BY_ID_WITH_LINKS, {
     variables: { id: courseId }
   })
-
-  const findPanEdges = () => {
-    if (!main.current || !concepts.current) {
-      return
-    }
-    let left = 0, top = 0, right = main.current.offsetWidth, bottom = main.current.offsetHeight
-    const paddingX = main.current.offsetWidth / 2
-    const paddingY = main.current.offsetHeight / 2
-    for (const state of Object.values(concepts.current)) {
-      if (state.x - paddingX <= left) left = state.x - paddingX
-      if (state.x + state.width + paddingX >= right) right = state.x + state.width + paddingX
-      if (state.y - paddingY <= top) top = state.y - paddingY
-      if (state.y + state.height + paddingY >= bottom) bottom = state.y + state.height + paddingY
-    }
-    edge.current = { left, top, right, bottom }
-  }
-
-  const clampPan = () => {
-    const height = main.current.offsetHeight
-    if (pan.current.y < edge.current.top)
-      pan.current.y = edge.current.top
-    else if (pan.current.y + height > edge.current.bottom)
-      pan.current.y = edge.current.bottom - height
-
-    const width = main.current.offsetWidth
-    if (pan.current.x < edge.current.left)
-      pan.current.x = edge.current.left
-    else if (pan.current.x + width > edge.current.right)
-      pan.current.x = edge.current.right - width
-  }
 
   const updateSelection = (axisKey, posKey, lenKey, value, offset) => {
     const initialValue = selection.current.start[axisKey]
@@ -225,7 +194,6 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
     if (panning.current) {
       pan.current.y -= evt.movementY
       pan.current.x -= evt.movementX
-      clampPan()
       main.current.style.transform =
         `translate(${-pan.current.x}px, ${-pan.current.y}px) scale(${pan.current.zoom})`
     } else if (selection.current) {
@@ -243,7 +211,6 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
     if (selection.current) {
       selection.current = null
       selectionRef.current.style.display = 'none'
-      findPanEdges()
     } else if (panning.current) {
       panning.current = false
     }
@@ -307,8 +274,6 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
-  useEffect(findPanEdges, [courseQuery.data.courseById?.concepts])
 
   if (courseQuery.error) {
     return <NotFoundView message='Course not found' />

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -89,6 +89,8 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
       selection.current.pos[posKey] = value + offset
       selection.current.pos[lenKey] = initialValue - value
     }
+    selection.current.pos[posKey] /= pan.current.zoom
+    selection.current.pos[lenKey] /= pan.current.zoom
     selectionRef.current.style[posKey] = `${selection.current.pos[posKey]}px`
     selectionRef.current.style[lenKey] = `${selection.current.pos[lenKey]}px`
   }
@@ -293,9 +295,8 @@ const ConceptMapperView = ({ workspaceId, courseId }) => {
     <main className={classes.root} ref={main}>
       {course.concepts.flatMap(concept => [
         <ConceptNode
-          key={concept.id} workspaceId={workspaceId} concept={concept}
-          openMenu={openMenu(concept.id)}
-          closeMenu={() => menu.id === concept.id && closeMenu()}
+          key={concept.id} workspaceId={workspaceId} concept={concept} pan={pan}
+          openMenu={openMenu(concept.id)} closeMenu={() => menu.id === concept.id && closeMenu()}
           concepts={concepts} selected={selected} submit={submitExistingConcept(concept.id)}
         />,
         ...concept.linksToConcept.map(link => <ConceptLink

--- a/frontend/src/views/conceptmapper/ConceptMapperView.js
+++ b/frontend/src/views/conceptmapper/ConceptMapperView.js
@@ -432,7 +432,7 @@ const ConceptMapperView = ({ workspaceId, courseId, urlPrefix }) => {
     <section className={classes.objectives}>
       <ObjectiveList
         openMenu={openMenu} closeMenu={closeMenuById} className={classes.objectiveList}
-        order={course.objectiveOrder} workspaceId={workspaceId}
+        order={course.objectiveOrder} workspaceId={workspaceId} pan={pan}
         concepts={course.concepts.filter(concept => concept.level === 'OBJECTIVE')}
       />
       <Button

--- a/frontend/src/views/conceptmapper/ConceptNode.js
+++ b/frontend/src/views/conceptmapper/ConceptNode.js
@@ -1,8 +1,10 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useState, useRef, useEffect, useLayoutEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { DraggableCore } from 'react-draggable'
 
-const useStyles = makeStyles({
+import { noPropagation } from '../../lib/eventMiddleware'
+
+const useStyles = makeStyles(theme => ({
   root: {
     position: 'absolute',
     padding: '5px',
@@ -10,13 +12,38 @@ const useStyles = makeStyles({
     borderRadius: '4px',
     cursor: 'pointer',
     boxSizing: 'border-box',
-    border: '1px solid gray'
+    border: '1px solid gray',
+    overflow: 'hidden',
+    '&.selected': {
+      border: '2px solid red',
+      padding: '4px'
+    }
+  },
+  editing: {
+    resize: 'both',
+    padding: 0,
+    '&.selected > $textarea': {
+      padding: '4px'
+    }
+  },
+  textarea: {
+    padding: '5px',
+    width: '100%',
+    height: '100%',
+    border: 'none',
+    margin: 0,
+    overflowY: 'auto',
+    scrollbarWidth: 'thin',
+    // Text inputs need font settings to be overridden
+    ...theme.typography.body2
   }
-})
+}))
 
 const parsePosition = position => {
   if (!position) {
-    return [{ x: 0, y: 0 }, { width: 300, height: 30 }]
+    return [{ x: 0, y: 0 }, { maxHeight: 60, maxWidth: 400, width: 'auto', height: 'auto' }]
+  } else if (typeof position !== 'string') {
+    return position
   }
   const [x, y, w, h] = position.split(',')
   return [{
@@ -28,18 +55,26 @@ const parsePosition = position => {
   }]
 }
 
-const ConceptNode = ({ concept, concepts, selected }) => {
+const ConceptNode = ({
+  concept, concepts, selected,
+  submit, cancel, isNew = false
+}) => {
   const classes = useStyles()
+  const [editing, setEditing] = useState(isNew)
+  const [name, setName] = useState(concept.name)
   const node = useRef()
+  const textArea = useRef()
   const pos = useRef()
   const size = useRef()
+  const prevPosition = useRef()
+  const isResizing = useRef(false)
   const id = `concept-${concept.id}`
 
-  useEffect(() => {
+  if (concept.position !== prevPosition.current) {
     [pos.current, size.current] = parsePosition(concept.position)
-    concepts.current[id] = { ...pos.current, ...size.current, node }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [concept.position])
+    concepts.current[id] = { ...pos.current, ...size.current, name, node }
+    prevPosition.current = concept.position
+  }
 
   useEffect(() => {
     window.addEventListener('moveConcept', handleMoveEvent)
@@ -49,39 +84,113 @@ const ConceptNode = ({ concept, concepts, selected }) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  useLayoutEffect(() => {
+
+  }, [])
+
   const updatePos = ({ deltaX, deltaY }) => {
     pos.current.x += deltaX
     pos.current.y += deltaY
     node.current.style.left = `${pos.current.x}px`
     node.current.style.top = `${pos.current.y}px`
-    concepts.current[id] = { ...pos.current, ...size.current, node }
+    concepts.current[id].x = pos.current.x
+    concepts.current[id].y = pos.current.y
   }
 
   const handleMoveEvent = evt => evt.detail.id !== id
     && selected.current.has(evt.detail.id) && selected.current.has(id)
     && updatePos(evt.detail)
 
-  const onDrag = (evt, { deltaX, deltaY }) => {
-    window.dispatchEvent(new CustomEvent('moveConcept', {
-      detail: {
-        id,
-        selected: selected.current.has(id) ? selected.current : null,
-        deltaX,
-        deltaY
+  if (editing) {
+    const onChange = evt => {
+      setName(evt.target.value)
+      concepts.current[id].name = evt.target.value
+    }
+
+    const onResizeStart = evt => isResizing.current = evt.target === node.current
+    const onResize = () => {
+      if (isResizing.current) {
+        size.current.width = node.current.offsetWidth
+        size.current.height = node.current.offsetHeight
+        concepts.current[id].width = size.current.width
+        concepts.current[id].height = size.current.height
       }
-    }))
-    updatePos({ deltaX, deltaY })
-  }
+    }
+    const onResizeStop = () => {
+      isResizing.current = false
+      concepts.current[id] = { ...pos.current, ...size.current, name, node }
+    }
 
-  const onStop = (evt, { x, y }) => {
-    console.log(concept.id, 'moved to', x, y)
-  }
+    const onKeyDown = evt => {
+      if (evt.key === 'Enter' && !evt.shiftKey) {
+        finishEdit()
+      } else if (evt.key === 'Escape') {
+        cancelEdit()
+      }
+    }
 
-  return <DraggableCore onDrag={onDrag} onStop={onStop}>
-    <div ref={node} className={classes.root} style={{ ...pos.current, ...size.current }} id={id}>
-      {concept.name}
-    </div>
-  </DraggableCore>
+    const cancelEdit = () => {
+      if (cancel) {
+        cancel()
+      }
+      if (!isNew) {
+        setEditing(false)
+      }
+    }
+
+    const finishEdit = async () => {
+      await submit({
+        name,
+        position: `${pos.current.x},${pos.current.y},${size.current.width},${size.current.height}`
+      })
+      if (!isNew) {
+        setEditing(false)
+      }
+    }
+
+    return (
+      <div
+        ref={node} className={`${classes.root} ${classes.editing}`} id={id}
+        style={{ left: pos.current.x, top: pos.current.y, ...size.current }}
+        onMouseDown={onResizeStart} onMouseMove={onResize} onMouseUp={onResizeStop}
+      >
+        <textarea
+          ref={textArea} className={classes.textarea} onChange={onChange} onBlur={finishEdit}
+          onKeyDown={onKeyDown} value={name} autoFocus
+        />
+      </div>
+    )
+  } else {
+    const onDrag = (evt, { deltaX, deltaY }) => {
+      window.dispatchEvent(new CustomEvent('moveConcept', {
+        detail: {
+          id,
+          selected: selected.current.has(id) ? selected.current : null,
+          deltaX,
+          deltaY
+        }
+      }))
+      updatePos({ deltaX, deltaY })
+    }
+
+    const onDragStop = () => {
+      submit({
+        position: `${pos.current.x},${pos.current.y},${size.current.width},${size.current.height}`
+      })
+    }
+
+    return (
+      <DraggableCore onDrag={onDrag} onStop={onDragStop}>
+        <div
+          ref={node} className={classes.root} id={id}
+          onDoubleClick={noPropagation(() => setEditing(true))}
+          style={{ left: pos.current.x, top: pos.current.y, ...size.current }}
+        >
+          {concept.name}
+        </div>
+      </DraggableCore>
+    )
+  }
 }
 
 export default ConceptNode

--- a/frontend/src/views/conceptmapper/ConceptNode.js
+++ b/frontend/src/views/conceptmapper/ConceptNode.js
@@ -15,12 +15,12 @@ const useStyles = makeStyles(theme => ({
     border: '1px solid gray',
     whiteSpace: 'pre-wrap',
     overflow: 'hidden',
+    '&:hover': {
+      border: '1px solid red'
+    },
     '&.selected': {
       border: '3px solid red',
       padding: '4px'
-    },
-    '&:hover': {
-      border: '1px solid red'
     },
     // Put these above the links
     zIndex: 5
@@ -161,8 +161,13 @@ const ConceptNode = ({
     }
 
     const finishEdit = async () => {
+      const trimmedName = name.trim()
+      if (trimmedName.length === 0) {
+        cancelEdit()
+        return
+      }
       await submit({
-        name: name.trim(),
+        name: trimmedName,
         position: positionString()
       })
       if (!isNew) {

--- a/frontend/src/views/conceptmapper/ConceptNode.js
+++ b/frontend/src/views/conceptmapper/ConceptNode.js
@@ -1,0 +1,87 @@
+import React, { useRef, useEffect } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import { DraggableCore } from 'react-draggable'
+
+const useStyles = makeStyles({
+  root: {
+    position: 'absolute',
+    padding: '5px',
+    backgroundColor: 'white',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    boxSizing: 'border-box',
+    border: '1px solid gray'
+  }
+})
+
+const parsePosition = position => {
+  if (!position) {
+    return [{ x: 0, y: 0 }, { width: 300, height: 30 }]
+  }
+  const [x, y, w, h] = position.split(',')
+  return [{
+    x: parseInt(x) || 0,
+    y: parseInt(y) || 0
+  }, {
+    width: parseInt(w) || 0,
+    height: parseInt(h) || 0
+  }]
+}
+
+const ConceptNode = ({ concept, concepts, selected }) => {
+  const classes = useStyles()
+  const node = useRef()
+  const pos = useRef()
+  const size = useRef()
+  const id = `concept-${concept.id}`
+
+  useEffect(() => {
+    [pos.current, size.current] = parsePosition(concept.position)
+    concepts.current[id] = { ...pos.current, ...size.current, node }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [concept.position])
+
+  useEffect(() => {
+    window.addEventListener('moveConcept', handleMoveEvent)
+    return () => {
+      window.removeEventListener('moveConcept', handleMoveEvent)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const updatePos = ({ deltaX, deltaY }) => {
+    pos.current.x += deltaX
+    pos.current.y += deltaY
+    node.current.style.left = `${pos.current.x}px`
+    node.current.style.top = `${pos.current.y}px`
+    concepts.current[id] = { ...pos.current, ...size.current, node }
+  }
+
+  const handleMoveEvent = evt => evt.detail.id !== id
+    && selected.current.has(evt.detail.id) && selected.current.has(id)
+    && updatePos(evt.detail)
+
+  const onDrag = (evt, { deltaX, deltaY }) => {
+    window.dispatchEvent(new CustomEvent('moveConcept', {
+      detail: {
+        id,
+        selected: selected.current.has(id) ? selected.current : null,
+        deltaX,
+        deltaY
+      }
+    }))
+    updatePos({ deltaX, deltaY })
+  }
+
+  const onStop = (evt, { x, y }) => {
+    console.log(concept.id, 'moved to', x, y)
+  }
+
+  return <DraggableCore onDrag={onDrag} onStop={onStop}>
+    <div ref={node} className={classes.root} style={{ ...pos.current, ...size.current }} id={id}>
+      {concept.name}
+    </div>
+  </DraggableCore>
+}
+
+export default ConceptNode

--- a/frontend/src/views/conceptmapper/ConceptNode.js
+++ b/frontend/src/views/conceptmapper/ConceptNode.js
@@ -65,7 +65,7 @@ const parsePosition = position => {
 }
 
 const ConceptNode = ({
-  concept, concepts, selected,
+  concept, concepts, selected, pan,
   openMenu, closeMenu, submit, cancel, isNew = false
 }) => {
   const classes = useStyles()
@@ -189,6 +189,8 @@ const ConceptNode = ({
     )
   } else {
     const onDrag = (evt, { deltaX, deltaY }) => {
+      deltaX /= pan.current.zoom
+      deltaY /= pan.current.zoom
       window.dispatchEvent(new CustomEvent('moveConcept', {
         detail: {
           id,

--- a/frontend/src/views/conceptmapper/ConceptNode.js
+++ b/frontend/src/views/conceptmapper/ConceptNode.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useLayoutEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import { DraggableCore } from 'react-draggable'
 
-import { noPropagation } from '../../lib/eventMiddleware'
+import { noPropagation, noDefault } from '../../lib/eventMiddleware'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -18,6 +18,9 @@ const useStyles = makeStyles(theme => ({
     '&.selected': {
       border: '3px solid red',
       padding: '4px'
+    },
+    '&:hover': {
+      border: '1px solid red'
     },
     // Put these above the links
     zIndex: 5
@@ -43,12 +46,12 @@ const useStyles = makeStyles(theme => ({
 
 const parsePosition = position => {
   if (!position) {
-    return { x: 0, y: 0, width: 300, height: 34 }
+    return { x: 0, y: 0, width: 200, height: 34 }
   } else if (typeof position !== 'string') {
     return {
       x: position.x || 0,
       y: position.y || 0,
-      width: position.width || 300,
+      width: position.width || 200,
       height: position.height || 34
     }
   }
@@ -56,14 +59,14 @@ const parsePosition = position => {
   return {
     x: parseInt(x) || 0,
     y: parseInt(y) || 0,
-    width: parseInt(w) || 300,
+    width: parseInt(w) || 200,
     height: parseInt(h) || 34
   }
 }
 
 const ConceptNode = ({
   concept, concepts, selected,
-  submit, cancel, isNew = false
+  openMenu, closeMenu, submit, cancel, isNew = false
 }) => {
   const classes = useStyles()
   const [editing, setEditing] = useState(isNew)
@@ -85,10 +88,6 @@ const ConceptNode = ({
       window.removeEventListener('moveConcept', handleMoveEvent)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useLayoutEffect(() => {
-
   }, [])
 
   const updatePos = ({ deltaX, deltaY }) => {
@@ -202,12 +201,17 @@ const ConceptNode = ({
       })
     }
 
+    const startEditing = () => {
+      closeMenu()
+      setEditing(true)
+    }
+
     return (
       <DraggableCore onDrag={onDrag} onStop={onDragStop}>
         <div
           ref={node => self.node = node} className={classes.root} id={id}
-          onDoubleClick={noPropagation(() => setEditing(true))}
-          style={positionStyle}
+          data-concept-id={concept.id} style={positionStyle}
+          onDoubleClick={noPropagation(startEditing)} onContextMenu={noDefault(openMenu)}
         >
           {concept.name}
         </div>

--- a/frontend/src/views/conceptmapper/ConceptNode.js
+++ b/frontend/src/views/conceptmapper/ConceptNode.js
@@ -146,6 +146,7 @@ const ConceptNode = ({
     const onKeyDown = evt => {
       if (evt.key === 'Enter' && !evt.shiftKey) {
         finishEdit()
+        evt.preventDefault()
       } else if (evt.key === 'Escape') {
         cancelEdit()
       }

--- a/frontend/src/views/conceptmapper/ConceptNode.js
+++ b/frontend/src/views/conceptmapper/ConceptNode.js
@@ -217,7 +217,7 @@ const ConceptNode = ({
     return (
       <DraggableCore onDrag={onDrag} onStop={onDragStop}>
         <div
-          ref={node => self.node = node} className={classes.root} id={id}
+          ref={node => self.node = node} className={`${classes.root} concept-root`} id={id}
           data-concept-id={concept.id} style={positionStyle}
           onDoubleClick={noPropagation(startEditing)} onContextMenu={noDefault(openMenu)}
         >

--- a/frontend/src/views/conceptmapper/CourseList.js
+++ b/frontend/src/views/conceptmapper/CourseList.js
@@ -1,0 +1,29 @@
+import { InputBase, MenuItem, Select } from '@material-ui/core'
+import React, { useState } from 'react'
+
+import useRouter from '../../lib/useRouter'
+
+const CourseList = ({ course, courses, urlPrefix, workspaceId }) => {
+  const [open, setOpen] = useState(false)
+  const { history } = useRouter()
+
+  return (
+    <Select
+      open={open}
+      value={course.id}
+      onClose={() => setOpen(false)}
+      onOpen={() => setOpen(true)}
+      input={<InputBase />}
+      onChange={evt => {
+        history.push(`${urlPrefix}/${workspaceId}/conceptmapper/${evt.target.value}`)
+        setOpen(false)
+      }}
+    >
+      {courses.map(course =>
+        <MenuItem key={course.id} value={course.id}>{course.name}</MenuItem>
+      )}
+    </Select>
+  )
+}
+
+export default CourseList

--- a/frontend/src/views/conceptmapper/ObjectiveList.js
+++ b/frontend/src/views/conceptmapper/ObjectiveList.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   }
 })
 
-const ObjectiveList = ({ workspaceId, order, concepts, openMenu, closeMenu }) => {
+const ObjectiveList = ({ workspaceId, order, concepts, openMenu, closeMenu, pan }) => {
   const classes = useStyles()
 
   const isOrdered = order.length === 1 && order[0].startsWith('__ORDER_BY__')
@@ -52,10 +52,10 @@ const ObjectiveList = ({ workspaceId, order, concepts, openMenu, closeMenu }) =>
     {concepts.flatMap(concept => [
       ...concept.linksToConcept.map(link => <ConceptLink
         key={link.id} delay={1} active linkId={link.id}
-        within='concept-mapper-link-container' // posOffsets={linkOffsets}
+        within='concept-mapper-link-container'
         onContextMenu={openMenu('concept-link', link.id)}
         posOffsets={{ x1: +6 }} toAnchor='center middle'
-        // scrollParentRef={pan}
+        scrollParentRefTo={pan}
         from={`objective-${concept.id}`} to={`concept-${link.from.id}`}
         fromConceptId={concept.id} toConceptId={link.from.id}
       />)

--- a/frontend/src/views/conceptmapper/ObjectiveList.js
+++ b/frontend/src/views/conceptmapper/ObjectiveList.js
@@ -50,15 +50,14 @@ const ObjectiveList = ({ workspaceId, order, concepts, openMenu, closeMenu }) =>
       )}
     </SortableList>
     {concepts.flatMap(concept => [
-      <ConceptLink key={concept.id} />,
       ...concept.linksToConcept.map(link => <ConceptLink
         key={link.id} delay={1} active linkId={link.id}
         within='concept-mapper-link-container' // posOffsets={linkOffsets}
         onContextMenu={openMenu('concept-link', link.id)}
+        posOffsets={{ x1: +6 }} toAnchor='center middle'
         // scrollParentRef={pan}
         from={`objective-${concept.id}`} to={`concept-${link.from.id}`}
         fromConceptId={concept.id} toConceptId={link.from.id}
-        fromAnchor='center middle' toAnchor='center middle'
       />)
     ])}
   </>

--- a/frontend/src/views/conceptmapper/ObjectiveList.js
+++ b/frontend/src/views/conceptmapper/ObjectiveList.js
@@ -1,31 +1,67 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import ReactDOM from 'react-dom'
+import { makeStyles } from '@material-ui/core/styles'
 
 import { SortableList } from '../../lib/sortableMoc'
 import ObjectiveNode from './ObjectiveNode'
 import { ConceptLink } from '../coursemapper/concept'
+import { sortedConcepts } from '../../lib/ordering'
+import arrayShift from '../../lib/arrayShift'
 
-const ObjectiveList = ({ objectiveOrder, concepts, openMenu, closeMenu, className }) => <>
-  <SortableList className={className}>
-    {concepts.map((concept, index) =>
-      <ObjectiveNode
-        key={concept.id} concept={concept} index={index}
-        openMenu={openMenu('objective', concept.id)}
-        closeMenu={closeMenu(concept.id)}
-      />
-    )}
-  </SortableList>
-  {concepts.flatMap(concept => [
-    <ConceptLink key={concept.id} />,
-    ...concept.linksToConcept.map(link => <ConceptLink
-      key={link.id} delay={1} active linkId={link.id}
-      within='concept-mapper-link-container' // posOffsets={linkOffsets}
-      onContextMenu={openMenu('concept-link', link.id)}
-      // scrollParentRef={pan}
-      from={`objective-${concept.id}`} to={`concept-${link.from.id}`}
-      fromConceptId={concept.id} toConceptId={link.from.id}
-      fromAnchor='center middle' toAnchor='center middle'
-    />)
-  ])}
-</>
+const useStyles = makeStyles({
+  root: {
+    flex: 1
+  }
+})
+
+const ObjectiveList = ({ workspaceId, order, concepts, openMenu, closeMenu }) => {
+  const classes = useStyles()
+
+  const isOrdered = order.length === 1 && order[0].startsWith('__ORDER_BY__')
+  const defaultOrderMethod = isOrdered ? order[0].substr('__ORDER_BY__'.length) : 'CUSTOM'
+  const [orderedConcepts, setOrderedConcepts] = useState([])
+  const [orderMethod, setOrderMethod] = useState(defaultOrderMethod)
+  const [dirtyOrder, setDirtyOrder] = useState(null)
+
+  useEffect(() => {
+    if (!dirtyOrder && defaultOrderMethod !== orderMethod) {
+      setOrderMethod(defaultOrderMethod)
+    }
+    if (!dirtyOrder || orderMethod !== 'CUSTOM') {
+      setOrderedConcepts(sortedConcepts(concepts, order, orderMethod))
+    }
+  }, [concepts, order, dirtyOrder, defaultOrderMethod, orderMethod])
+
+  const onSortEnd = ({ oldIndex, newIndex }) =>
+    ReactDOM.unstable_batchedUpdates(() => {
+      setOrderedConcepts(items => arrayShift(items, oldIndex, newIndex))
+      if (!dirtyOrder) setDirtyOrder('yes')
+      if (orderMethod !== 'CUSTOM') setOrderMethod('CUSTOM')
+    })
+
+  return <>
+    <SortableList className={classes.root} useDragHandle lockAxis='y' onSortEnd={onSortEnd}>
+      {orderedConcepts.map((concept, index) =>
+        <ObjectiveNode
+          key={concept.id} concept={concept} index={index} workspaceId={workspaceId}
+          openMenu={openMenu('objective', concept.id)}
+          closeMenu={closeMenu(concept.id)}
+        />
+      )}
+    </SortableList>
+    {concepts.flatMap(concept => [
+      <ConceptLink key={concept.id} />,
+      ...concept.linksToConcept.map(link => <ConceptLink
+        key={link.id} delay={1} active linkId={link.id}
+        within='concept-mapper-link-container' // posOffsets={linkOffsets}
+        onContextMenu={openMenu('concept-link', link.id)}
+        // scrollParentRef={pan}
+        from={`objective-${concept.id}`} to={`concept-${link.from.id}`}
+        fromConceptId={concept.id} toConceptId={link.from.id}
+        fromAnchor='center middle' toAnchor='center middle'
+      />)
+    ])}
+  </>
+}
 
 export default ObjectiveList

--- a/frontend/src/views/conceptmapper/ObjectiveList.js
+++ b/frontend/src/views/conceptmapper/ObjectiveList.js
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import { SortableList } from '../../lib/sortableMoc'
+import ObjectiveNode from './ObjectiveNode'
+import { ConceptLink } from '../coursemapper/concept'
+
+const ObjectiveList = ({ objectiveOrder, concepts, openMenu, closeMenu, className }) => <>
+  <SortableList className={className}>
+    {concepts.map((concept, index) =>
+      <ObjectiveNode
+        key={concept.id} concept={concept} index={index}
+        openMenu={openMenu('objective', concept.id)}
+        closeMenu={closeMenu(concept.id)}
+      />
+    )}
+  </SortableList>
+  {concepts.flatMap(concept => [
+    <ConceptLink key={concept.id} />,
+    ...concept.linksToConcept.map(link => <ConceptLink
+      key={link.id} delay={1} active linkId={link.id}
+      within='concept-mapper-link-container' // posOffsets={linkOffsets}
+      onContextMenu={openMenu('concept-link', link.id)}
+      // scrollParentRef={pan}
+      from={`objective-${concept.id}`} to={`concept-${link.from.id}`}
+      fromConceptId={concept.id} toConceptId={link.from.id}
+      fromAnchor='center middle' toAnchor='center middle'
+    />)
+  ])}
+</>
+
+export default ObjectiveList

--- a/frontend/src/views/conceptmapper/ObjectiveNode.js
+++ b/frontend/src/views/conceptmapper/ObjectiveNode.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { IconButton, ListItemText, ListItemSecondaryAction, Typography } from '@material-ui/core'
+import { Delete as DeleteIcon, Edit as EditIcon } from '@material-ui/icons'
+import { makeStyles } from '@material-ui/core/styles'
+
+import { SortableItem } from '../../lib/sortableMoc'
+
+const useStyles = makeStyles(() => ({
+  hoverButton: {
+    visibility: 'hidden'
+  },
+  conceptBody: {
+    paddingRight: '56px'
+  },
+  listItemContainer: {
+    '&:hover': {
+      '& $hoverButton': {
+        visibility: 'visible'
+      },
+      '& $conceptBody': {
+        paddingRight: '160px'
+      }
+    }
+  }
+}))
+
+const ObjectiveNode = ({ concept, index }) => {
+  const classes = useStyles()
+
+  const handleDelete = () => {
+    const msg = `Are you sure you want to delete the objetcive ${concept.name}?`
+    if (window.confirm(msg)) {
+      deleteConcept(concept.id)
+    }
+  }
+
+  const handleEdit = () => alert('Not yet implemented')
+
+  return (
+    <SortableItem index={index} classes={{ divider: classes.listItemContainer }}>
+      <ListItemText className={classes.conceptBody}>
+        <Typography variant='h6' className={classes.conceptName}>
+          {concept.name}
+        </Typography>
+      </ListItemText>
+      <ListItemSecondaryAction>
+        <IconButton
+          title={concept.frozen ? 'This concept is frozen' : undefined}
+          disabled={concept.frozen} className={classes.hoverButton} onClick={handleDelete}
+        >
+          <DeleteIcon />
+        </IconButton>
+        <IconButton className={classes.hoverButton} onClick={handleEdit}>
+          <EditIcon />
+        </IconButton>
+      </ListItemSecondaryAction>
+    </SortableItem>
+  )
+}
+
+export default ObjectiveNode

--- a/frontend/src/views/conceptmapper/ObjectiveNode.js
+++ b/frontend/src/views/conceptmapper/ObjectiveNode.js
@@ -71,7 +71,7 @@ const ObjectiveNode = ({ workspaceId, concept, index }) => {
       ContainerProps={{ 'data-concept-id': concept.id }}
     >
       <ListItemIcon>
-        <IconButton onClick={() => alert('Not yet implemented')} className={classes.conceptCircle}>
+        <IconButton onClick={() => alert('Not yet implemented')} className={classes.conceptCircle} id={`objective-${concept.id}`}>
           <ArrowLeftIcon viewBox='7 7 10 10' id={`objective-circle-${concept.id}`} />
         </IconButton>
       </ListItemIcon>

--- a/frontend/src/views/coursemapper/concept/ConceptLink.js
+++ b/frontend/src/views/coursemapper/concept/ConceptLink.js
@@ -139,7 +139,7 @@ export default class ConceptLink extends Component {
       const sp = scrollParentRef?.current
       const pageXOffset = sp ? sp.scrollLeft || sp.x : window.pageXOffset
       const pageYOffset = sp ? sp.scrollTop || sp.y : window.pageYOffset
-      const zoom = sp?.zoom || 0
+      const zoom = sp?.zoom || 1
 
       const x0 = (fromBox.x + (fromBox.width * this.fromAnchor.x) + pageXOffset + offset.x0) / zoom
       const y0 = (fromBox.y + (fromBox.height * this.fromAnchor.y) + pageYOffset + offset.y0) / zoom

--- a/frontend/src/views/coursemapper/concept/ConceptLink.js
+++ b/frontend/src/views/coursemapper/concept/ConceptLink.js
@@ -239,6 +239,28 @@ const Line = ({
     recalculate()
   }
 
+  const handleMoveEvent = evt => {
+    let changed = false, bothChanged = false
+    if (evt.detail.id === from || (evt.detail.selected && evt.detail.selected.has(from))) {
+      pos.current.x0 += evt.detail.deltaX
+      pos.current.y0 += evt.detail.deltaY
+      changed = true
+    }
+    if (evt.detail.id === to || (evt.detail.selected && evt.detail.selected.has(to))) {
+      pos.current.x1 += evt.detail.deltaX
+      pos.current.y1 += evt.detail.deltaY
+      bothChanged = changed
+      changed = true
+    }
+    if (bothChanged) {
+      // Don't even bother with the angle recalculation
+      el.current.style.top = `${pos.current.y0}px`
+      el.current.style.left = `${pos.current.x0}px`
+    } else if (changed) {
+      recalculate()
+    }
+  }
+
   const elCallback = node => {
     el.current = node
     if (linkRef) {
@@ -255,11 +277,13 @@ const Line = ({
   useEffect(() => {
     window.addEventListener('resize', handleResize)
     window.addEventListener('redrawConceptLink', handleResize)
+    window.addEventListener('moveConcept', handleMoveEvent)
     window.addEventListener('scroll', handleResize, true)
     // componentWillUnmount
     return () => {
       window.removeEventListener('resize', handleResize)
       window.removeEventListener('redrawConceptLink', handleResize)
+      window.removeEventListener('moveConcept', handleMoveEvent)
       window.removeEventListener('scroll', handleResize)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/views/coursemapper/concept/ConceptLink.js
+++ b/frontend/src/views/coursemapper/concept/ConceptLink.js
@@ -239,7 +239,7 @@ const Line = ({
     recalculate()
   }
 
-  const handleMoveEvent = evt => {
+  const handleConceptMoveEvent = evt => {
     let changed = false, bothChanged = false
     if (evt.detail.id === from || (evt.detail.selected && evt.detail.selected.has(from))) {
       pos.current.x0 += evt.detail.deltaX
@@ -277,13 +277,15 @@ const Line = ({
   useEffect(() => {
     window.addEventListener('resize', handleResize)
     window.addEventListener('redrawConceptLink', handleResize)
-    window.addEventListener('moveConcept', handleMoveEvent)
+    window.addEventListener('resizeConcept', handleConceptMoveEvent)
+    window.addEventListener('moveConcept', handleConceptMoveEvent)
     window.addEventListener('scroll', handleResize, true)
     // componentWillUnmount
     return () => {
       window.removeEventListener('resize', handleResize)
       window.removeEventListener('redrawConceptLink', handleResize)
-      window.removeEventListener('moveConcept', handleMoveEvent)
+      window.removeEventListener('resizeConcept', handleConceptMoveEvent)
+      window.removeEventListener('moveConcept', handleConceptMoveEvent)
       window.removeEventListener('scroll', handleResize)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/views/coursemapper/concept/ConceptLink.js
+++ b/frontend/src/views/coursemapper/concept/ConceptLink.js
@@ -139,11 +139,12 @@ export default class ConceptLink extends Component {
       const sp = scrollParentRef?.current
       const pageXOffset = sp ? sp.scrollLeft || sp.x : window.pageXOffset
       const pageYOffset = sp ? sp.scrollTop || sp.y : window.pageYOffset
+      const zoom = sp?.zoom || 0
 
-      const x0 = fromBox.x + (fromBox.width * this.fromAnchor.x) + pageXOffset + offset.x0
-      const y0 = fromBox.y + (fromBox.height * this.fromAnchor.y) + pageYOffset + offset.y0
-      const x1 = toBox.x + (toBox.width * this.toAnchor.x) + pageXOffset + offset.x1
-      const y1 = toBox.y + (toBox.height * this.toAnchor.y) + pageYOffset + offset.y1
+      const x0 = (fromBox.x + (fromBox.width * this.fromAnchor.x) + pageXOffset + offset.x0) / zoom
+      const y0 = (fromBox.y + (fromBox.height * this.fromAnchor.y) + pageYOffset + offset.y0) / zoom
+      const x1 = (toBox.x + (toBox.width * this.toAnchor.x) + pageXOffset + offset.x1) / zoom
+      const y1 = (toBox.y + (toBox.height * this.toAnchor.y) + pageYOffset + offset.y1) / zoom
 
       return { x0, y0, x1, y1 }
     }

--- a/frontend/src/views/coursemapper/concept/ConceptLink.js
+++ b/frontend/src/views/coursemapper/concept/ConceptLink.js
@@ -117,7 +117,9 @@ export default class ConceptLink extends Component {
   }
 
   detect() {
-    const { from: fromId, to: toId, scrollParentRef } = this.props
+    const {
+      from: fromId, to: toId, scrollParentRef, scrollParentFromRef, scrollParentToRef
+    } = this.props
 
     const fromRef = this.fromRef
     const toRef = this.toRef
@@ -131,20 +133,22 @@ export default class ConceptLink extends Component {
     const offset = { x0: 0, y0: 0, x1: 0, y1: 0, ...this.props.posOffsets }
 
     return () => {
-      const fromBox = fromRef.current.getBoundingClientRect()
-      const toBox = toRef.current.getBoundingClientRect()
-      fromRef.current.classList.add(`linkto-${this.props.toConceptId}`)
-      toRef.current.classList.add(`linkto-${this.props.fromConceptId}`)
+      const calculatePosition = (spRef, ref, anchor, dir) => {
+        const sp = (spRef !== undefined ? spRef : scrollParentRef)?.current
+        const pageXOffset = sp ? sp.scrollLeft || sp.x : window.pageXOffset
+        const pageYOffset = sp ? sp.scrollTop || sp.y : window.pageYOffset
+        const zoom = sp?.zoom || 1
+        const box = ref.current.getBoundingClientRect()
+        ref.current.classList.add(`linkto-${this.props[`${dir}ConceptId`]}`)
+        const index = dir === 'to' ? 0 : 1
+        return [
+          (box.x + (box.width * anchor.x) + pageXOffset + offset[`x${index}`]) / zoom,
+          (box.y + (box.height * anchor.y) + pageYOffset + offset[`y${index}`]) / zoom
+        ]
+      }
 
-      const sp = scrollParentRef?.current
-      const pageXOffset = sp ? sp.scrollLeft || sp.x : window.pageXOffset
-      const pageYOffset = sp ? sp.scrollTop || sp.y : window.pageYOffset
-      const zoom = sp?.zoom || 1
-
-      const x0 = (fromBox.x + (fromBox.width * this.fromAnchor.x) + pageXOffset + offset.x0) / zoom
-      const y0 = (fromBox.y + (fromBox.height * this.fromAnchor.y) + pageYOffset + offset.y0) / zoom
-      const x1 = (toBox.x + (toBox.width * this.toAnchor.x) + pageXOffset + offset.x1) / zoom
-      const y1 = (toBox.y + (toBox.height * this.toAnchor.y) + pageYOffset + offset.y1) / zoom
+      const [x0, y0] = calculatePosition(scrollParentFromRef, fromRef, this.fromAnchor, 'from')
+      const [x1, y1] = calculatePosition(scrollParentToRef, toRef, this.toAnchor, 'to')
 
       return { x0, y0, x1, y1 }
     }

--- a/frontend/src/views/coursemapper/concept/ConceptLink.js
+++ b/frontend/src/views/coursemapper/concept/ConceptLink.js
@@ -137,8 +137,8 @@ export default class ConceptLink extends Component {
       toRef.current.classList.add(`linkto-${this.props.fromConceptId}`)
 
       const sp = scrollParentRef?.current
-      const pageXOffset = sp ? sp.scrollLeft : window.pageXOffset
-      const pageYOffset = sp ? sp.scrollTop : window.pageYOffset
+      const pageXOffset = sp ? sp.scrollLeft || sp.x : window.pageXOffset
+      const pageYOffset = sp ? sp.scrollTop || sp.y : window.pageYOffset
 
       const x0 = fromBox.x + (fromBox.width * this.fromAnchor.x) + pageXOffset + offset.x0
       const y0 = fromBox.y + (fromBox.height * this.fromAnchor.y) + pageYOffset + offset.y0

--- a/frontend/src/views/coursemapper/redirect/MapperRedirectView.js
+++ b/frontend/src/views/coursemapper/redirect/MapperRedirectView.js
@@ -6,8 +6,10 @@ import { WORKSPACE_BY_ID } from '../../../graphql/Query/Workspace'
 import CreateCourseForm from './CreateCourseForm'
 import NotFoundView from '../../error/NotFoundView'
 import LoadingBar from '../../../components/LoadingBar'
+import useRouter from '../../../lib/useRouter'
 
-const MapperRedirectView = ({ workspaceId, location, urlPrefix }) => {
+const MapperRedirectView = ({ workspaceId, urlPrefix }) => {
+  const { location } = useRouter()
   const workspaceQuery = useQuery(WORKSPACE_BY_ID, {
     variables: {
       id: workspaceId

--- a/frontend/src/views/members/MembersView.js
+++ b/frontend/src/views/members/MembersView.js
@@ -13,7 +13,6 @@ import EditableTable, { Type } from '../../components/EditableTable'
 import { useLoginStateValue } from '../../lib/store'
 import { DELETE_PARTICIPANT, UPDATE_PARTICIPANT } from '../../graphql/Mutation'
 import useRouter from '../../lib/useRouter'
-import cache from '../../apollo/update'
 import {
   useUpdatingSubscription
 } from '../../apollo/useUpdatingSubscription'

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8699,6 +8699,14 @@ react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.15.0"
 
+react-draggable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.1.0.tgz#e1c5b774001e32f0bff397254e1e9d5448ac92a4"
+  integrity sha512-Or/qe70cfymshqoC8Lsp0ukTzijJObehb7Vfl7tb5JRxoV+b6PDkOGoqYaWBzZ59k9dH/bwraLGsnlW78/3vrA==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react-error-overlay@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.2.tgz#642bd6157c6a4b6e9ca4a816f7ed30b868c47f81"


### PR DESCRIPTION
Fixes #437 

TODO:
* [x] Panning and zooming
  * [ ] ~~Edge limit for panning~~ too difficult for now
  * [x] Zoom limit
  * [x] Zoom into cursor position (currently zooms to top left corner)
* [x] Basic context menu for links and background
* [x] Button to open concept mapper in workspace navbar
* [ ] Concept context menu
  * [ ] Open full editor dialog in add concept
  * [ ] New button or dialog option for adding objective
  * [ ] Deselect
  * [ ] Delete all selected
  * [ ] Convert existing concept/objective to objective/concept
* [ ] Toolbar
  * [x] Course switcher
  * [ ] Selected concept actions (edit, delete, deselect)
* [ ] Save all position changes when moving many concepts
  * [ ] Mutation in backend for mass editing
  * [ ] Use mutation in frontend
* [ ] Show difference between concepts and objectives with colors or something