### PR TITLE
Add some space between goal view halfs

### DIFF
--- a/frontend/src/views/goals/Courses.js
+++ b/frontend/src/views/goals/Courses.js
@@ -17,7 +17,7 @@ export const Courses = ({ workspaceId, courses, tagOptions, onClickCircle }) => 
   const deleteCourse = useMutation(DELETE_COURSE, { update: cache.deleteCourseUpdate(workspaceId) })
 
   return (
-    <Card elevation={0} className={classes.card}>
+    <Card elevation={0} className={`${classes.card} ${classes.courses}`}>
       <CardHeader title='Courses' />
       <List className={classes.list}>
         {courses.map(course => editing === course.id ? (

--- a/frontend/src/views/goals/GoalView.js
+++ b/frontend/src/views/goals/GoalView.js
@@ -81,6 +81,7 @@ const GoalView = ({ workspaceId }) => {
     <div className={classes.root} onClick={() => setAddingLink(null)}>
       <h1 className={classes.title}>Goal Mapping</h1>
       <Courses courses={courses} workspaceId={workspaceId} tagOptions={courseTags} onClickCircle={onClickCircle} />
+      <div style={{gridArea: 'space'}} />
       <Goals goals={goals} workspaceId={workspaceId} tagOptions={goalTags} onClickCircle={onClickCircle} />
       <div>
         {goalLinks.map(link => <ConceptLink

--- a/frontend/src/views/goals/Goals.js
+++ b/frontend/src/views/goals/Goals.js
@@ -23,7 +23,7 @@ export const Goals = ({ workspaceId, goals, tagOptions, onClickCircle }) => {
   })
 
   return (
-    <Card elevation={0} className={classes.card}>
+    <Card elevation={0} className={`${classes.card} ${classes.goals}`}>
       <CardHeader title='Goals' />
       <List className={classes.list}>
         {goals.map(goal => editing === goal.id ? (

--- a/frontend/src/views/goals/styles.js
+++ b/frontend/src/views/goals/styles.js
@@ -11,7 +11,7 @@ export const useStyles = makeStyles(theme => ({
     gridTemplate: `"header  header header" 56px
                    "courses space  goals"  1fr
                   / 1fr     128px  1fr`,
-    '@media screen and (max-width: 1312px)': {
+    '@media screen and (max-width: 1440px)': {
       width: 'calc(100% - 32px)'
     }
   },

--- a/frontend/src/views/goals/styles.js
+++ b/frontend/src/views/goals/styles.js
@@ -3,14 +3,14 @@ import { makeStyles } from '@material-ui/core/styles'
 export const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
-    maxWidth: '1280px',
+    maxWidth: '1408px',
     margin: '0 auto',
     display: 'grid',
     overflow: 'hidden',
     gridGap: '16px',
-    gridTemplate: `"header  header"   56px
-                   "courses goals" 1fr
-                  / 1fr     1fr`,
+    gridTemplate: `"header  header header" 56px
+                   "courses space  goals"  1fr
+                  / 1fr     128px  1fr`,
     '@media screen and (max-width: 1312px)': {
       width: 'calc(100% - 32px)'
     }
@@ -24,6 +24,12 @@ export const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     overflow: 'hidden'
+  },
+  courses: {
+    gridArea: 'courses'
+  },
+  goals: {
+    gridArea: 'goals'
   },
   list: {
     overflow: 'auto'


### PR DESCRIPTION
Might make more sense to use flex with `justify-content: space-between`, but this adds a bit of space between the two halfs in the goal view as an initial solution.