### PR TITLE
Fix projects without active templates

### DIFF
--- a/frontend/src/components/BaseWorkspaceList.js
+++ b/frontend/src/components/BaseWorkspaceList.js
@@ -306,7 +306,7 @@ This will change which template is cloned by users.`,
         sublistMap[ws.sourceTemplate.id].push(makeWorkspaceItem(ws))
       }
     }
-    workspaceList = [
+    workspaceList = activeTemplate === null ? [] : [
       sublistMap[activeTemplate.id],
       <Divider style={{ marginBottom: '8px' }} key={`divider-${activeTemplate.id}`} />,
       ...Object.entries(sublistMap)


### PR DESCRIPTION
When a project is created it does not have an active template. However, after the active template is selected it can no longer be removed or unset.